### PR TITLE
Feat: AddIOp operation from StandardOps

### DIFF
--- a/test/Btor/dummy.mlir
+++ b/test/Btor/dummy.mlir
@@ -4,7 +4,7 @@ module {
     // CHECK-LABEL: func @bar()
     func @bar() {
         %0 = constant 1 : i32
-        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
+        // CHECK: %{{.*}} = addi %{{.*}}, %{{.*}} : i32
         %res = addi %0, %0 : i32
         return
     }

--- a/test/Btor/dummy.mlir
+++ b/test/Btor/dummy.mlir
@@ -5,7 +5,7 @@ module {
     func @bar() {
         %0 = constant 1 : i32
         // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
-        %res = btor.add %0 %0 : i32
+        %res = addi %0, %0 : i32
         return
     }
 }

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -16,7 +16,7 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'STANDALONE'
+config.name = 'BTOR'
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
@@ -54,8 +54,8 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
 tool_dirs = [config.standalone_tools_dir, config.llvm_tools_dir]
 tools = [
-    'standalone-opt',
-    'standalone-translate'
+    'btor-opt',
+    'btor-translate'
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -27,7 +27,7 @@ config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.standalone_obj_root, 'test')
+config.test_exec_root = os.path.join(config.btor_obj_root, 'test')
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
@@ -46,13 +46,13 @@ config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENS
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.standalone_obj_root, 'test')
-config.standalone_tools_dir = os.path.join(config.standalone_obj_root, 'bin')
+config.test_exec_root = os.path.join(config.btor_obj_root, 'test')
+config.btor_tools_dir = os.path.join(config.btor_obj_root, 'bin')
 
 # Tweak the PATH to include the tools dir.
 llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
-tool_dirs = [config.standalone_tools_dir, config.llvm_tools_dir]
+tool_dirs = [config.btor_tools_dir, config.llvm_tools_dir]
 tools = [
     'btor-opt',
     'btor-translate'

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -29,8 +29,8 @@ config.host_ldflags = '@HOST_LDFLAGS@'
 config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
 config.llvm_host_triple = '@LLVM_HOST_TRIPLE@'
 config.host_arch = "@HOST_ARCH@"
-config.standalone_src_root = "@CMAKE_SOURCE_DIR@"
-config.standalone_obj_root = "@CMAKE_BINARY_DIR@"
+config.btor_src_root = "@CMAKE_SOURCE_DIR@"
+config.btor_obj_root = "@CMAKE_BINARY_DIR@"
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
Since we have added both the BtorOpsDialect and StandardOpsDialect, we can give our program the following `.mlir` file:

```
// RUN: btor-opt %s | btor-opt | FileCheck %s

module {
    // CHECK-LABEL: func @bar()
    func @bar() {
        %0 = constant 1 : i32
        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
        %res = addi %0, %0 : i32
        return
    }
}
```

and it will return:

```
module  {
  func @bar() {
    %c1_i32 = constant 1 : i32
    %0 = addi %c1_i32, %c1_i32 : i32
    return
  }
}
```
