### PR TITLE
BtorToStd: Add conversion pass from btor.addOp to std.addIOp

### DIFF
--- a/include/Conversion/BtorToStandard/ConvertBtorToStandardPass.h
+++ b/include/Conversion/BtorToStandard/ConvertBtorToStandardPass.h
@@ -4,11 +4,19 @@
 #include <memory>
 
 namespace mlir {
+struct LogicalResult;
 class Pass;
 
+class RewritePatternSet;
+using OwningRewritePatternList = RewritePatternSet;
+
 namespace btor {
+    /// Collect a set of patterns to lower from btor.add to Standard dialect
+    void populateBtorToStdConversionPatterns(RewritePatternSet &patterns);
+
     /// Creates a pass to convert the Btor dialect into the Standard dialect.
     std::unique_ptr<mlir::Pass> createLowerToStandardPass();
+
     /// Registers said pass
     void registerBtorToStandardPass();
 

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -22,7 +22,7 @@ def AddOp : Btor_Op<"add", [NoSideEffect, SameOperandsAndResultType, Commutative
         ```mlir
         %0 = constant 2 : i32
         %1 = constant 4 : i32
-        // Apply the foo operation to %0
+        // Apply the add operation to %0 and %1
         %2 = btor.add %0 %1 : i32
         ```
     }];


### PR DESCRIPTION
Given the following input file which has a mixture of operations defined using StdOps (`constant`) and BtorOps (`btor.add`):
```
// RUN: btor-opt %s | btor-opt | FileCheck %s

module {
    // CHECK-LABEL: func @bar()
    func @bar() {
        %0 = constant 1 : i32
        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
        %1 = constant 42 : i32
        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
        %2 = btor.add %0 %1: i32
        return
    }
}
```

We can get our pass generating the following standard dialect IR:
`./debug/bin/btor2mlir-opt test/Btor/btor-opt.mlir --convert-btor-to-std`

```
module  {
  func @bar() {
    %c1_i32 = constant 1 : i32
    %c42_i32 = constant 42 : i32
    %0 = addi %c1_i32, %c42_i32 : i32
    return
  }
}
```

We can then apply the built in pass to go from std to llvm:
`./debug/bin/btor2mlir-opt test/Btor/btor-opt.mlir --convert-btor-to-std --convert-std-to-llvm`

```
module attributes {llvm.data_layout = ""}  {
  llvm.func @bar() {
    %0 = llvm.mlir.constant(1 : i32) : i32
    %1 = llvm.mlir.constant(42 : i32) : i32
    %2 = llvm.mlir.constant(43 : i32) : i32
    llvm.return
  }
}
```