### PR TITLE
BtorOps: Add btor.mul, btor.and, btor.eq and btor.bad 

### DIFF
--- a/include/Dialect/Btor/IR/BtorDialect.h
+++ b/include/Dialect/Btor/IR/BtorDialect.h
@@ -11,6 +11,6 @@
 
 #include "mlir/IR/Dialect.h"
 
-#include "Btor/BtorOpsDialect.h.inc"
+#include "Dialect/Btor/IR/BtorOpsDialect.h.inc"
 
 #endif // BTOR_BTORDIALECT_H

--- a/include/Dialect/Btor/IR/BtorOps.h
+++ b/include/Dialect/Btor/IR/BtorOps.h
@@ -15,6 +15,6 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
-#include "Btor/BtorOps.h.inc"
+#include "Dialect/Btor/IR/BtorOps.h.inc"
 
 #endif // BTOR_BTOROPS_H

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -81,4 +81,33 @@ def AndOp : Btor_Op<"and", [NoSideEffect, SameOperandsAndResultType, Commutative
     }];
 }
 
+def EqOp : Btor_Op<"eq", [NoSideEffect, SameTypeOperands]> {
+    let summary = "integer binary equality comparison";
+    let description = [{
+        This operation takes two integer arguments and returns an integer (I1).
+
+        Example:
+        
+        ```mlir
+        %0 = constant 2 : i32
+        %1 = constant 4 : i32
+        // Apply the eq operation to %0 and %1
+        %2 = btor.eq %0 %1 : i1
+        ```
+    }];
+
+    let arguments = (ins I32:$lhs, I32:$rhs);
+    let results = (outs I1:$res);
+
+    let assemblyFormat = [{
+        $lhs $rhs attr-dict `:` type($res)
+    }];
+
+    // Allow building an EqOp with from the two input operands.
+    let builders = [
+    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
+      build($_builder, $_state, lhs, rhs);
+    }]>];
+}
+
 #endif // BTOR_OPS

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -35,4 +35,27 @@ def AddOp : Btor_Op<"add", [NoSideEffect, SameOperandsAndResultType, Commutative
     }];
 }
 
+def MulOp : Btor_Op<"mul", [NoSideEffect, SameOperandsAndResultType, Commutative]> {
+    let summary = "integer multiplication operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %0 = constant 2 : i32
+        %1 = constant 4 : i32
+        // Apply the mul operation to %0 and %1
+        %2 = btor.mul %0 %1 : i32
+        ```
+    }];
+
+    let arguments = (ins I32:$lhs, I32:$rhs);
+    let results = (outs I32:$res);
+
+    let assemblyFormat = [{
+        $lhs $rhs attr-dict `:` type($lhs)
+    }];
+}
+
 #endif // BTOR_OPS

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -58,4 +58,27 @@ def MulOp : Btor_Op<"mul", [NoSideEffect, SameOperandsAndResultType, Commutative
     }];
 }
 
+def AndOp : Btor_Op<"and", [NoSideEffect, SameOperandsAndResultType, Commutative]> {
+    let summary = "integer binary and operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %0 = constant 2 : i32
+        %1 = constant 4 : i32
+        // Apply the mul operation to %0 and %1
+        %2 = btor.and %0 %1 : i32
+        ```
+    }];
+
+    let arguments = (ins I32:$lhs, I32:$rhs);
+    let results = (outs I32:$res);
+
+    let assemblyFormat = [{
+        $lhs $rhs attr-dict `:` type($lhs)
+    }];
+}
+
 #endif // BTOR_OPS

--- a/lib/Conversion/BtorToStandard/BtorToStandard.cpp
+++ b/lib/Conversion/BtorToStandard/BtorToStandard.cpp
@@ -21,10 +21,23 @@ struct BtorToStandardLoweringPass : public PassWrapper<BtorToStandardLoweringPas
 };
 } // end anonymous namespace
 
+//===----------------------------------------------------------------------===//
+// Lowering Declarations
+//===----------------------------------------------------------------------===//
+
 struct AddLowering : public OpRewritePattern<AddOp> {
     using OpRewritePattern<AddOp>::OpRewritePattern;
-    LogicalResult matchAndRewrite(AddOp addOp,PatternRewriter &rewriter) const override;
+    LogicalResult matchAndRewrite(AddOp addOp, PatternRewriter &rewriter) const override;
 };
+
+struct MulLowering : public OpRewritePattern<MulOp> {
+    using OpRewritePattern<MulOp>::OpRewritePattern;
+    LogicalResult matchAndRewrite(MulOp mulOp, PatternRewriter &rewriter) const override;
+};
+
+//===----------------------------------------------------------------------===//
+// Lowering Definitions
+//===----------------------------------------------------------------------===//
 
 LogicalResult AddLowering::matchAndRewrite(AddOp addOp, PatternRewriter &rewriter) const {
     Location loc = addOp.getLoc();
@@ -37,8 +50,23 @@ LogicalResult AddLowering::matchAndRewrite(AddOp addOp, PatternRewriter &rewrite
     return success();
 }
 
+LogicalResult MulLowering::matchAndRewrite(MulOp mulOp, PatternRewriter &rewriter) const {
+    Location loc = mulOp.getLoc();
+    Value lhs = mulOp.lhs();
+    Value rhs = mulOp.rhs();
+
+    Value mulIOp = rewriter.create<mlir::MulIOp>(loc, lhs, rhs);
+    rewriter.replaceOp(mulOp, mulIOp);
+    
+    return success();
+}
+
+//===----------------------------------------------------------------------===//
+// Populate Lowering Patterns
+//===----------------------------------------------------------------------===//
+
 void mlir::btor::populateBtorToStdConversionPatterns(RewritePatternSet &patterns) {
-  patterns.add<AddLowering>(patterns.getContext());
+  patterns.add<AddLowering, MulLowering>(patterns.getContext());
 }
 
 void BtorToStandardLoweringPass::runOnOperation() {
@@ -46,7 +74,7 @@ void BtorToStandardLoweringPass::runOnOperation() {
     populateBtorToStdConversionPatterns(patterns);
     /// Configure conversion to lower out btor.add; Anything else is fine.
     ConversionTarget target(getContext());
-    target.addIllegalOp<AddOp>();
+    target.addIllegalOp<AddOp, MulOp>();
     target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
     if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
         signalPassFailure();

--- a/lib/Dialect/Btor/IR/BtorDialect.cpp
+++ b/lib/Dialect/Btor/IR/BtorDialect.cpp
@@ -12,7 +12,7 @@
 using namespace mlir;
 using namespace mlir::btor;
 
-#include "Btor/BtorOpsDialect.cpp.inc"
+#include "Dialect/Btor/IR/BtorOpsDialect.cpp.inc"
 
 //===----------------------------------------------------------------------===//
 // Btor dialect.
@@ -21,6 +21,6 @@ using namespace mlir::btor;
 void BtorDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
-#include "Btor/BtorOps.cpp.inc"
+#include "Dialect/Btor/IR/BtorOps.cpp.inc"
       >();
 }

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -9,6 +9,7 @@
 #include "Dialect/Btor/IR/BtorDialect.h"
 #include "Dialect/Btor/IR/BtorOps.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Builders.h"
 
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -11,4 +11,4 @@
 #include "mlir/IR/OpImplementation.h"
 
 #define GET_OP_CLASSES
-#include "Btor/BtorOps.cpp.inc"
+#include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -8,6 +8,8 @@ module {
         %1 = constant 42 : i32
         // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
         %2 = btor.add %0 %1: i32
+        // CHECK: %{{.*}} = btor.mul %{{.*}} %{{.*}} : i32
+        %3 = btor.mul %0 %2: i32
         return
     }
 }


### PR DESCRIPTION
New Operations have been added to support more expression from the set of operations that we have in btor. The file below can now be submitted:

```
// RUN: btor2mlir-opt %s | btor2mlir-opt | FileCheck %s

module {
    // CHECK-LABEL: func @bar()
    func @bar() {
        %0 = constant 1 : i32
        // CHECK: %{{.*}} = constant {{.*}} : i32
        %1 = constant 42 : i32
        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
        %2 = btor.add %0 %1: i32
        // CHECK: %{{.*}} = btor.mul %{{.*}} %{{.*}} : i32
        %3 = btor.mul %0 %2: i32
        // CHECK: %{{.*}} = btor.eq %{{.*}} %{{.*}}
        %4 = btor.eq %3 %2 : i1
        // CHECK: %{{.*}} = btor.bad %{{.*}}
        btor.bad %4
        return
    }
}
```

When run with ` ./debug/bin/btor2mlir-opt --convert-btor-to-std test/Btor/btor-opt.mlir`, we get:
```
module  {
  func @bar() {
    %c1_i32 = constant 1 : i32
    %c42_i32 = constant 42 : i32
    %0 = addi %c1_i32, %c42_i32 : i32
    %1 = muli %c1_i32, %0 : i32
    %2 = cmpi eq, %1, %0 : i32
    assert %2, "Expects argument to be true"
    return
  }
}
```

On the other hand, when we add the std-to-llvm conversion pass (`./debug/bin/btor2mlir-opt --convert-btor-to-std --convert-std-to-llvm test/Btor/btor-opt.mlir`), we get:

```
module attributes {llvm.data_layout = ""}  {
  llvm.func @abort()
  llvm.func @bar() {
    %0 = llvm.mlir.constant(1 : i32) : i32
    %1 = llvm.mlir.constant(42 : i32) : i32
    %2 = llvm.mlir.constant(43 : i32) : i32
    %3 = llvm.mul %0, %2  : i32
    %4 = llvm.icmp "eq" %3, %2 : i32
    llvm.cond_br %4, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    llvm.return
  ^bb2:  // pred: ^bb0
    llvm.call @abort() : () -> ()
    llvm.unreachable
  }
}
```

