### PR TITLE
Fix assert op

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -99,6 +99,8 @@ def EqOp : Btor_Op<"eq", [NoSideEffect, SameTypeOperands]> {
     let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
     let results = (outs BoolLike:$res);
 
+    // At the moment, we use the assemblyFormat below to say that we 
+    // are going from inputs of type $lhs to an output of type $res.
     let assemblyFormat = [{
         $lhs $rhs attr-dict `:` type($lhs) type($res)
     }];

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -27,8 +27,8 @@ def AddOp : Btor_Op<"add", [NoSideEffect, SameOperandsAndResultType, Commutative
         ```
     }];
 
-    let arguments = (ins I32:$lhs, I32:$rhs);
-    let results = (outs I32:$res);
+    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
+    let results = (outs SignlessIntegerLike:$res);
 
     let assemblyFormat = [{
         $lhs $rhs attr-dict `:` type($lhs)
@@ -50,8 +50,8 @@ def MulOp : Btor_Op<"mul", [NoSideEffect, SameOperandsAndResultType, Commutative
         ```
     }];
 
-    let arguments = (ins I32:$lhs, I32:$rhs);
-    let results = (outs I32:$res);
+    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
+    let results = (outs SignlessIntegerLike:$res);
 
     let assemblyFormat = [{
         $lhs $rhs attr-dict `:` type($lhs)
@@ -73,8 +73,8 @@ def AndOp : Btor_Op<"and", [NoSideEffect, SameOperandsAndResultType, Commutative
         ```
     }];
 
-    let arguments = (ins I32:$lhs, I32:$rhs);
-    let results = (outs I32:$res);
+    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
+    let results = (outs SignlessIntegerLike:$res);
 
     let assemblyFormat = [{
         $lhs $rhs attr-dict `:` type($lhs)
@@ -96,11 +96,11 @@ def EqOp : Btor_Op<"eq", [NoSideEffect, SameTypeOperands]> {
         ```
     }];
 
-    let arguments = (ins I32:$lhs, I32:$rhs);
-    let results = (outs I1:$res);
+    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
+    let results = (outs BoolLike:$res);
 
     let assemblyFormat = [{
-        $lhs $rhs attr-dict `:` type($res)
+        $lhs $rhs attr-dict `:` type($lhs) type($res)
     }];
 
     // Allow building an EqOp with from the two input operands.
@@ -108,6 +108,26 @@ def EqOp : Btor_Op<"eq", [NoSideEffect, SameTypeOperands]> {
     OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
       build($_builder, $_state, lhs, rhs);
     }]>];
+}
+
+def BadOp : Btor_Op<"bad"> {
+    let summary = "btor assertion";
+    let description = [{
+        This operation takes one boolean argument terminates the 
+        program if the argument is false.
+
+        Example:
+        
+        ```mlir
+        %0 = constant 1 : i1
+        // Apply the bad operation to %0
+        btor.bad %0
+        ```
+    }];
+
+    let arguments = (ins I1:$arg);
+
+    let assemblyFormat = "$arg attr-dict";
 }
 
 #endif // BTOR_OPS

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -3,13 +3,17 @@
 module {
     // CHECK-LABEL: func @bar()
     func @bar() {
-        %0 = constant 1 : i32
-        // CHECK: %{{.*}} = constant {{.*}} : i32
-        %1 = constant 42 : i32
-        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i32
-        %2 = btor.add %0 %1: i32
-        // CHECK: %{{.*}} = btor.mul %{{.*}} %{{.*}} : i32
-        %3 = btor.mul %0 %2: i32
+        %0 = constant 7 : i3
+        // CHECK: %{{.*}} = constant {{.*}} : i3
+        %1 = constant 3 : i3
+        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i3
+        %2 = btor.add %0 %1: i3
+        // CHECK: %{{.*}} = btor.mul %{{.*}} %{{.*}} : i3
+        %3 = btor.mul %0 %2: i3
+        // CHECK: %{{.*}} = btor.eq %{{.*}} %{{.*}}
+        %4 = btor.eq %3 %2 : i3 i1
+        // CHECK: %{{.*}} = btor.bad %{{.*}}
+        btor.bad %4
         return
     }
 }


### PR DESCRIPTION
Now, given the following BTOR-IR input:

```
module  {
  func @bar() {
    %c-1_i3 = constant -1 : i3
    %c3_i3 = constant 3 : i3
    %0 = btor.add %c-1_i3 %c3_i3 : i3
    %1 = btor.mul %c-1_i3 %0 : i3
    %2 = btor.eq %1 %0 : i3 i1
    btor.bad %2
    return
  }
}
```

We can generate the following LLVMIR

```
module attributes {llvm.data_layout = ""}  {
  llvm.func @abort()
  llvm.func @bar() {
    %0 = llvm.mlir.constant(-1 : i3) : i3
    %1 = llvm.mlir.constant(3 : i3) : i3
    %2 = llvm.mlir.constant(2 : i3) : i3
    %3 = llvm.mul %0, %2  : i3
    %4 = llvm.icmp "eq" %3, %2 : i3
    %5 = llvm.mlir.constant(false) : i1
    %6 = llvm.icmp "eq" %5, %4 : i1
    llvm.cond_br %6, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    llvm.return
  ^bb2:  // pred: ^bb0
    llvm.call @abort() : () -> ()
    llvm.unreachable
  }
}
```

One thing to note: The `btor.eq` operation was a little hard to build using default builders. Specifically, specifying the argument and return types in the assembly format. At the moment, we use the line `%2 = btor.eq %1 %0 : i3 i1` to say that we are going from inputs of type `i3` to an output of type `i1`