### PR TITLE
Replace btor.eq with btor.cmp

### DIFF
--- a/include/Dialect/Btor/IR/BtorDialect.td
+++ b/include/Dialect/Btor/IR/BtorDialect.td
@@ -12,6 +12,28 @@
 include "mlir/IR/OpBase.td"
 
 //===----------------------------------------------------------------------===//
+// btor constants definition.
+//===----------------------------------------------------------------------===//
+
+def BTOR_EQ  : I64EnumAttrCase<"eq", 0>;
+def BTOR_NE  : I64EnumAttrCase<"ne", 1>;
+def BTOR_SLT : I64EnumAttrCase<"slt", 2>;
+def BTOR_SLE : I64EnumAttrCase<"sle", 3>;
+def BTOR_SGT : I64EnumAttrCase<"sgt", 4>;
+def BTOR_SGE : I64EnumAttrCase<"sge", 5>;
+def BTOR_ULT : I64EnumAttrCase<"ult", 6>;
+def BTOR_ULE : I64EnumAttrCase<"ule", 7>;
+def BTOR_UGT : I64EnumAttrCase<"ugt", 8>;
+def BTOR_UGE : I64EnumAttrCase<"uge", 9>;
+
+def BtorPredicateAttr : I64EnumAttr<
+    "BtorPredicate", "btor.cmp comparison predicate",
+    [BTOR_EQ, BTOR_NE, BTOR_SLT, BTOR_SLE, BTOR_SGT,
+     BTOR_SGE, BTOR_ULT, BTOR_ULE, BTOR_UGT, BTOR_UGE]> {
+  let cppNamespace = "::mlir::btor";
+}
+
+//===----------------------------------------------------------------------===//
 // Btor dialect definition.
 //===----------------------------------------------------------------------===//
 

--- a/include/Dialect/Btor/IR/BtorOps.h
+++ b/include/Dialect/Btor/IR/BtorOps.h
@@ -10,9 +10,11 @@
 #define BTOR_BTOROPS_H
 
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+
+// Pull in all enum type definitions and utility function declarations.
+#include "Dialect/Btor/IR/BtorOpsEnums.h.inc"
 
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.h.inc"

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -12,7 +12,47 @@
 include "BtorDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-def AddOp : Btor_Op<"add", [NoSideEffect, SameOperandsAndResultType, Commutative]> {
+//===----------------------------------------------------------------------===//
+// btor binary integer ops definitions
+//===----------------------------------------------------------------------===//
+
+// Base class for btor arithmetic operations.  Requires operands and
+// results to be of the same type, but does not constrain them to specific
+// types.
+class BtorArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
+    Op<Btor_Dialect, mnemonic, traits 
+    #[NoSideEffect, SameOperandsAndResultType] #ElementwiseMappable.traits> {
+
+  let results = (outs AnyType:$result);
+
+  let parser = [{
+    return impl::parseOneResultSameOperandTypeOp(parser, result);
+  }];
+
+  let printer = [{
+    return printBtorBinaryOp(this->getOperation(), p);
+  }];
+}
+
+// This operation takes two operands and returns one result,
+// each of these is required to be of the same type.
+//  The custom assembly form of the operation is as follows
+//
+//     <op>i %0, %1 : i32
+class BtorBinaryOp<string mnemonic, list<OpTrait> traits = []> :
+    BtorArithmeticOp<mnemonic, traits>,
+    Arguments<(ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs)> {
+
+  let parser = [{
+    return impl::parseOneResultSameOperandTypeOp(parser, result);
+  }];
+
+  let printer = [{
+    return printBtorBinaryOp(this->getOperation(), p);
+  }];
+}
+
+def AddOp : BtorBinaryOp<"add", [Commutative]> {
     let summary = "integer addition operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -20,22 +60,12 @@ def AddOp : Btor_Op<"add", [NoSideEffect, SameOperandsAndResultType, Commutative
         Example:
         
         ```mlir
-        %0 = constant 2 : i32
-        %1 = constant 4 : i32
-        // Apply the add operation to %0 and %1
-        %2 = btor.add %0 %1 : i32
+        %res = btor.add %lhs, %rhs : i32
         ```
-    }];
-
-    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
-    let results = (outs SignlessIntegerLike:$res);
-
-    let assemblyFormat = [{
-        $lhs $rhs attr-dict `:` type($lhs)
     }];
 }
 
-def MulOp : Btor_Op<"mul", [NoSideEffect, SameOperandsAndResultType, Commutative]> {
+def MulOp : BtorBinaryOp<"mul", [Commutative]> {
     let summary = "integer multiplication operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -43,22 +73,12 @@ def MulOp : Btor_Op<"mul", [NoSideEffect, SameOperandsAndResultType, Commutative
         Example:
         
         ```mlir
-        %0 = constant 2 : i32
-        %1 = constant 4 : i32
-        // Apply the mul operation to %0 and %1
-        %2 = btor.mul %0 %1 : i32
+        %res = btor.mul %lhs, %rhs : i32
         ```
-    }];
-
-    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
-    let results = (outs SignlessIntegerLike:$res);
-
-    let assemblyFormat = [{
-        $lhs $rhs attr-dict `:` type($lhs)
     }];
 }
 
-def AndOp : Btor_Op<"and", [NoSideEffect, SameOperandsAndResultType, Commutative]> {
+def OrOp : BtorBinaryOp<"or", [Commutative]> {
     let summary = "integer binary and operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -66,57 +86,29 @@ def AndOp : Btor_Op<"and", [NoSideEffect, SameOperandsAndResultType, Commutative
         Example:
         
         ```mlir
-        %0 = constant 2 : i32
-        %1 = constant 4 : i32
-        // Apply the mul operation to %0 and %1
-        %2 = btor.and %0 %1 : i32
+        %res = btor.or %lhs, %rhs : i32
         ```
-    }];
-
-    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
-    let results = (outs SignlessIntegerLike:$res);
-
-    let assemblyFormat = [{
-        $lhs $rhs attr-dict `:` type($lhs)
     }];
 }
 
-def EqOp : Btor_Op<"eq", [NoSideEffect, SameTypeOperands]> {
-    let summary = "integer binary equality comparison";
+def AndOp : BtorBinaryOp<"and", [Commutative]> {
+    let summary = "integer binary and operation";
     let description = [{
-        This operation takes two integer arguments and returns an integer (I1).
+        This operation takes two integer arguments and returns an integer.
 
         Example:
         
         ```mlir
-        %0 = constant 2 : i32
-        %1 = constant 4 : i32
-        // Apply the eq operation to %0 and %1
-        %2 = btor.eq %0 %1 : i1
+        %res = btor.and %lhs, %rhs : i32
         ```
     }];
-
-    let arguments = (ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs);
-    let results = (outs BoolLike:$res);
-
-    // At the moment, we use the assemblyFormat below to say that we 
-    // are going from inputs of type $lhs to an output of type $res.
-    let assemblyFormat = [{
-        $lhs $rhs attr-dict `:` type($lhs) type($res)
-    }];
-
-    // Allow building an EqOp with from the two input operands.
-    let builders = [
-    OpBuilder<(ins "Value":$lhs, "Value":$rhs), [{
-      build($_builder, $_state, lhs, rhs);
-    }]>];
 }
 
 def BadOp : Btor_Op<"bad"> {
     let summary = "btor assertion";
     let description = [{
-        This operation takes one boolean argument terminates the 
-        program if the argument is false.
+        This operation takes one boolean argument and terminates
+        the program if the argument is false.
 
         Example:
         
@@ -130,6 +122,105 @@ def BadOp : Btor_Op<"bad"> {
     let arguments = (ins I1:$arg);
 
     let assemblyFormat = "$arg attr-dict";
+}
+
+def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
+     TypesMatchWith<"result type has i1 element type and same shape as operands",
+    "lhs", "result", "getI1SameShape($_self)">] # ElementwiseMappable.traits> {
+  let summary = "integer comparison operation";
+  let description = [{
+    The `cmp` operation is a generic comparison for two arguments 
+    that need to have their types matching.
+
+    Its first argument is an attribute that defines which type of comparison is
+    performed. The following comparisons are supported:
+
+    -   equal (mnemonic: `"eq"`; integer value: `0`)
+    -   not equal (mnemonic: `"ne"`; integer value: `1`)
+    -   signed less than (mnemonic: `"slt"`; integer value: `2`)
+    -   signed less than or equal (mnemonic: `"sle"`; integer value: `3`)
+    -   signed greater than (mnemonic: `"sgt"`; integer value: `4`)
+    -   signed greater than or equal (mnemonic: `"sge"`; integer value: `5`)
+    -   unsigned less than (mnemonic: `"ult"`; integer value: `6`)
+    -   unsigned less than or equal (mnemonic: `"ule"`; integer value: `7`)
+    -   unsigned greater than (mnemonic: `"ugt"`; integer value: `8`)
+    -   unsigned greater than or equal (mnemonic: `"uge"`; integer value: `9`)
+
+    The result is `1` if the comparison is true and `0` otherwise.
+
+    Example:
+
+    ```mlir
+    // Custom form of scalar "signed less than" comparison.
+    %x = cmp "slt", %lhs, %rhs : i32
+    ```
+  }];
+
+  let arguments = (ins
+      BtorPredicateAttr:$predicate,
+      SignlessIntegerLike:$lhs,
+      SignlessIntegerLike:$rhs
+  );
+  let results = (outs BoolLike:$result);
+
+  let builders = [
+    OpBuilder<(ins "BtorPredicate":$predicate, "Value":$lhs,
+                 "Value":$rhs), [{
+      ::buildCmpOp($_builder, $_state, predicate, lhs, rhs);
+    }]>];
+
+  
+  let extraClassDeclaration = [{
+    static StringRef getPredicateAttrName() { return "predicate"; }
+    static BtorPredicate getPredicateByName(StringRef name);
+
+    BtorPredicate getPredicate() {
+      return (BtorPredicate)(*this)->getAttrOfType<IntegerAttr>(
+          getPredicateAttrName()).getInt();
+    }
+  }];
+
+  let verifier = [{ return success(); }];
+
+  let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
+} 
+
+//===----------------------------------------------------------------------===//
+// btor unary integer ops definitions
+//===----------------------------------------------------------------------===//
+
+// Base class for unary ops. Requires single operand and result. Individual
+// classes will have `operand` accessor.
+class BtorUnaryOp<string mnemonic, list<OpTrait> traits = []> :
+    Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])>,
+    Arguments<(ins SignlessIntegerLike:$operand)> {
+
+  let results = (outs AnyType);
+
+  let printer = [{
+    return printBtorUnaryOp(this->getOperation(), p);
+  }];
+
+  let parser = [{
+    return impl::parseOneResultSameOperandTypeOp(parser, result);
+  }];
+}
+
+def NotOp : BtorUnaryOp<"not"> {
+  let summary = "integer negation";
+  let description = [{
+    Syntax:
+
+    The `not` operation computes the negation of a given value. It takes one
+    operand and returns one result of the same type. 
+
+    Example:
+
+    ```mlir
+    // Scalar negation value.
+    %a = not %b : i32
+    ```
+  }];
 }
 
 #endif // BTOR_OPS

--- a/include/Dialect/Btor/IR/CMakeLists.txt
+++ b/include/Dialect/Btor/IR/CMakeLists.txt
@@ -1,3 +1,10 @@
-add_mlir_dialect(BtorOps btor)
-add_mlir_doc(BtorDialect BtorDialect Dialect/ -gen-dialect-doc)
-add_mlir_doc(BtorOps BtorOps Dialect/ -gen-op-doc)
+set(LLVM_TARGET_DEFINITIONS BtorOps.td)
+mlir_tablegen(BtorOps.h.inc -gen-op-decls)
+mlir_tablegen(BtorOps.cpp.inc -gen-op-defs)
+mlir_tablegen(BtorOpsDialect.h.inc -gen-dialect-decls)
+mlir_tablegen(BtorOpsDialect.cpp.inc -gen-dialect-defs)
+mlir_tablegen(BtorOpsEnums.h.inc -gen-enum-decls)
+mlir_tablegen(BtorOpsEnums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(MLIRBtorOpsIncGen)
+
+add_mlir_doc(BtorOps BtorOps Dialects/ -gen-op-doc)

--- a/lib/Dialect/Btor/IR/BtorDialect.cpp
+++ b/lib/Dialect/Btor/IR/BtorDialect.cpp
@@ -9,10 +9,13 @@
 #include "Dialect/Btor/IR/BtorDialect.h"
 #include "Dialect/Btor/IR/BtorOps.h"
 
+#include "Dialect/Btor/IR/BtorOpsDialect.cpp.inc"
+
+// Pull in all enum type definitions and utility function declarations.
+#include "Dialect/Btor/IR/BtorOpsEnums.cpp.inc"
+
 using namespace mlir;
 using namespace mlir::btor;
-
-#include "Dialect/Btor/IR/BtorOpsDialect.cpp.inc"
 
 //===----------------------------------------------------------------------===//
 // Btor dialect.

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -11,5 +11,63 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Builders.h"
 
+using namespace mlir;
+using namespace mlir::btor;
+
+/// A custom unary operation printer that omits the "std." prefix from the
+/// operation names.
+static void printBtorUnaryOp(Operation *op, OpAsmPrinter &p) {
+  assert(op->getNumOperands() == 1 && "unary op should have one operand");
+  assert(op->getNumResults() == 1 && "unary op should have one result");
+
+  p << ' ' << op->getOperand(0);
+  p.printOptionalAttrDict(op->getAttrs());
+  p << " : " << op->getOperand(0).getType();
+}
+
+/// A custom binary operation printer that omits the "btor." prefix from the
+/// operation names.
+static void printBtorBinaryOp(Operation *op, OpAsmPrinter &p) {
+  assert(op->getNumOperands() == 2 && "binary op should have two operands");
+  assert(op->getNumResults() == 1 && "binary op should have one result");
+
+  // If not all the operand and result types are the same, just use the
+  // generic assembly form to avoid omitting information in printing.
+  auto resultType = op->getResult(0).getType();
+  if (op->getOperand(0).getType() != resultType ||
+      op->getOperand(1).getType() != resultType) {
+    p.printGenericOp(op);
+    return;
+  }
+
+  p << ' ' << op->getOperand(0) << ", " << op->getOperand(1);
+  p.printOptionalAttrDict(op->getAttrs());
+
+  // Now we can output only one type for all operands and the result.
+  p << " : " << op->getResult(0).getType();
+}
+
+//===----------------------------------------------------------------------===//
+// General helpers for comparison ops
+//===----------------------------------------------------------------------===//
+
+// Return the type of the same shape (scalar, vector or tensor) containing i1.
+static Type getI1SameShape(Type type) {
+  auto i1Type = IntegerType::get(type.getContext(), 1);
+  return i1Type;
+}
+
+//===----------------------------------------------------------------------===//
+// CmpOp
+//===----------------------------------------------------------------------===//
+
+static void buildCmpOp(OpBuilder &build, OperationState &result,
+                        BtorPredicate predicate, Value lhs, Value rhs) {
+  result.addOperands({lhs, rhs});
+  result.types.push_back(getI1SameShape(lhs.getType()));
+  result.addAttribute(CmpOp::getPredicateAttrName(),
+                      build.getI64IntegerAttr(static_cast<int64_t>(predicate)));
+}
+
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -6,12 +6,12 @@ module {
         %0 = constant 7 : i3
         // CHECK: %{{.*}} = constant {{.*}} : i3
         %1 = constant 3 : i3
-        // CHECK: %{{.*}} = btor.add %{{.*}} %{{.*}} : i3
-        %2 = btor.add %0 %1: i3
-        // CHECK: %{{.*}} = btor.mul %{{.*}} %{{.*}} : i3
-        %3 = btor.mul %0 %2: i3
+        // CHECK: %{{.*}} = btor.add %{{.*}}, %{{.*}} : i3
+        %2 = btor.add %0, %1 : i3
+        // CHECK: %{{.*}} = btor.mul %{{.*}}, %{{.*}} : i3
+        %3 = btor.mul %0, %2 : i3
         // CHECK: %{{.*}} = btor.eq %{{.*}} %{{.*}}
-        %4 = btor.eq %3 %2 : i3 i1
+        %4 = btor.cmp "ne", %3, %2 : i3
         // CHECK: %{{.*}} = btor.bad %{{.*}}
         btor.bad %4
         return


### PR DESCRIPTION
We can now support the following comparison operations: `eq`, `ne`, `slt`, `sle`, `sgt`, `sge`, `ult`, `ule`, `ugt`, `uge`

Moreover, there has been some cleanup to the basic arithmetic operations to mimic the patterns used by MLIR developers.

![](https://media.giphy.com/media/CuMiNoTRz2bYc/giphy.gif)