### PR TITLE
Adding more btor ops

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -393,6 +393,23 @@ def DecOp : BtorUnaryOp<"dec", [SameOperandsAndResultType]> {
   }];
 }
 
+def NegOp : BtorUnaryOp<"neg", [SameOperandsAndResultType]> {
+  let summary = "integer negation";
+  let description = [{
+    Syntax:
+
+    The `neg` operation flips the sign of a given value. It takes one
+    operand and returns one result of the same type. 
+
+    Example:
+
+    ```mlir
+    // Scalar decrement value.
+    %a = btor.neg %b : i32
+    ```
+  }];
+}
+
 def RedAndOp : BtorUnaryOp<"redand"> {
   let summary = "integer reduction with and operator";
   let description = [{

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -231,7 +231,7 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
 } 
 
 def SRemOp : BtorBinaryOp<"srem", [Commutative]> {
-    let summary = "integer binary signed remainder operation";
+    let summary = "integer signed remainder operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
 
@@ -239,6 +239,84 @@ def SRemOp : BtorBinaryOp<"srem", [Commutative]> {
         
         ```mlir
         %res = btor.srem %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def URemOp : BtorBinaryOp<"urem", [Commutative]> {
+    let summary = "integer unsigned remainder operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.urem %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def SDivOp : BtorBinaryOp<"sdiv", [Commutative]> {
+    let summary = "integer signed division operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.sdiv %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def UDivOp : BtorBinaryOp<"udiv", [Commutative]> {
+    let summary = "integer unsigned division operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.udiv %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def ShiftLLOp : BtorBinaryOp<"sll", [Commutative]> {
+    let summary = "integer left logical shift binary operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.sll %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def ShiftRLOp : BtorBinaryOp<"srl", [Commutative]> {
+    let summary = "integer right logical shift operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.srl %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def ShiftRAOp : BtorBinaryOp<"sra", [Commutative]> {
+    let summary = "integer right arithmetic shift operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.sra %lhs, %rhs : i32
         ```
     }];
 }

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -65,6 +65,19 @@ def AddOp : BtorBinaryOp<"add", [Commutative]> {
     }];
 }
 
+def SubOp : BtorBinaryOp<"sub"> {
+    let summary = "integer subtraction operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.sub %lhs, %rhs : i32
+        ```
+    }];
+}
+
 def MulOp : BtorBinaryOp<"mul", [Commutative]> {
     let summary = "integer multiplication operation";
     let description = [{
@@ -204,7 +217,7 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
 
     ```mlir
     // Custom form of scalar "signed less than" comparison.
-    %x = cmp "slt", %lhs, %rhs : i32
+    %x = btor.cmp "slt", %lhs, %rhs : i32
     ```
   }];
 
@@ -270,7 +283,41 @@ def NotOp : BtorUnaryOp<"not", [SameOperandsAndResultType]> {
 
     ```mlir
     // Scalar negation value.
-    %a = not %b : i32
+    %a = btor.not %b : i32
+    ```
+  }];
+}
+
+def IncOp : BtorUnaryOp<"inc", [SameOperandsAndResultType]> {
+  let summary = "integer increment by one";
+  let description = [{
+    Syntax:
+
+    The `inc` operation increments the given value by one. It takes one
+    operand and returns one result of the same type. 
+
+    Example:
+
+    ```mlir
+    // Scalar increment value.
+    %a = btor.inc %b : i32
+    ```
+  }];
+}
+
+def DecOp : BtorUnaryOp<"dec", [SameOperandsAndResultType]> {
+  let summary = "integer decrement by one";
+  let description = [{
+    Syntax:
+
+    The `dec` operation decrements the given value by one. It takes one
+    operand and returns one result of the same type. 
+
+    Example:
+
+    ```mlir
+    // Scalar decrement value.
+    %a = btor.dec %b : i32
     ```
   }];
 }
@@ -287,7 +334,7 @@ def RedAndOp : BtorUnaryOp<"redand"> {
 
     ```mlir
     // Scalar redand value.
-    %a = redand %b : i32
+    %a = btor.redand %b : i32
     ```
   }];
 }

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -278,7 +278,7 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
   let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
 } 
 
-def SRemOp : BtorBinaryOp<"srem", [Commutative]> {
+def SRemOp : BtorBinaryOp<"srem"> {
     let summary = "integer signed remainder operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -291,7 +291,7 @@ def SRemOp : BtorBinaryOp<"srem", [Commutative]> {
     }];
 }
 
-def URemOp : BtorBinaryOp<"urem", [Commutative]> {
+def URemOp : BtorBinaryOp<"urem"> {
     let summary = "integer unsigned remainder operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -304,7 +304,7 @@ def URemOp : BtorBinaryOp<"urem", [Commutative]> {
     }];
 }
 
-def SDivOp : BtorBinaryOp<"sdiv", [Commutative]> {
+def SDivOp : BtorBinaryOp<"sdiv"> {
     let summary = "integer signed division operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -317,7 +317,7 @@ def SDivOp : BtorBinaryOp<"sdiv", [Commutative]> {
     }];
 }
 
-def UDivOp : BtorBinaryOp<"udiv", [Commutative]> {
+def UDivOp : BtorBinaryOp<"udiv"> {
     let summary = "integer unsigned division operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -330,7 +330,7 @@ def UDivOp : BtorBinaryOp<"udiv", [Commutative]> {
     }];
 }
 
-def ShiftLLOp : BtorBinaryOp<"sll", [Commutative]> {
+def ShiftLLOp : BtorBinaryOp<"sll"> {
     let summary = "integer left logical shift binary operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -343,7 +343,7 @@ def ShiftLLOp : BtorBinaryOp<"sll", [Commutative]> {
     }];
 }
 
-def ShiftRLOp : BtorBinaryOp<"srl", [Commutative]> {
+def ShiftRLOp : BtorBinaryOp<"srl"> {
     let summary = "integer right logical shift operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.
@@ -356,7 +356,7 @@ def ShiftRLOp : BtorBinaryOp<"srl", [Commutative]> {
     }];
 }
 
-def ShiftRAOp : BtorBinaryOp<"sra", [Commutative]> {
+def ShiftRAOp : BtorBinaryOp<"sra"> {
     let summary = "integer right arithmetic shift operation";
     let description = [{
         This operation takes two integer arguments and returns an integer.

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -369,6 +369,32 @@ def ShiftRAOp : BtorBinaryOp<"sra"> {
     }];
 }
 
+def RotateLOp : BtorBinaryOp<"rol"> {
+    let summary = "integer left rotate operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.rol %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def RotateROp : BtorBinaryOp<"ror"> {
+    let summary = "integer right rotate operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.ror %lhs, %rhs : i32
+        ```
+    }];
+}
+
 //===----------------------------------------------------------------------===//
 // btor unary integer ops definitions
 //===----------------------------------------------------------------------===//

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -91,6 +91,19 @@ def OrOp : BtorBinaryOp<"or", [Commutative]> {
     }];
 }
 
+def NorOp : BtorBinaryOp<"nor", [Commutative]> {
+    let summary = "integer binary nor operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.nor %lhs, %rhs : i32
+        ```
+    }];
+}
+
 def AndOp : BtorBinaryOp<"and", [Commutative]> {
     let summary = "integer binary and operation";
     let description = [{
@@ -104,6 +117,19 @@ def AndOp : BtorBinaryOp<"and", [Commutative]> {
     }];
 }
 
+def NandOp : BtorBinaryOp<"nand", [Commutative]> {
+    let summary = "integer binary nand operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.nand %lhs, %rhs : i32
+        ```
+    }];
+}
+
 def XOrOp : BtorBinaryOp<"xor", [Commutative]> {
     let summary = "integer binary xor operation";
     let description = [{
@@ -113,6 +139,19 @@ def XOrOp : BtorBinaryOp<"xor", [Commutative]> {
         
         ```mlir
         %res = btor.xor %lhs, %rhs : i32
+        ```
+    }];
+}
+
+def XnorOp : BtorBinaryOp<"xnor", [Commutative]> {
+    let summary = "integer binary xnor operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.xnor %lhs, %rhs : i32
         ```
     }];
 }
@@ -205,7 +244,7 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
 // Base class for unary ops. Requires single operand and result. Individual
 // classes will have `operand` accessor.
 class BtorUnaryOp<string mnemonic, list<OpTrait> traits = []> :
-    Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect, SameOperandsAndResultType])>,
+    Op<Btor_Dialect, mnemonic, !listconcat(traits, [NoSideEffect])>,
     Arguments<(ins SignlessIntegerLike:$operand)> {
 
   let results = (outs AnyType);
@@ -219,7 +258,7 @@ class BtorUnaryOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 }
 
-def NotOp : BtorUnaryOp<"not"> {
+def NotOp : BtorUnaryOp<"not", [SameOperandsAndResultType]> {
   let summary = "integer negation";
   let description = [{
     Syntax:
@@ -232,6 +271,23 @@ def NotOp : BtorUnaryOp<"not"> {
     ```mlir
     // Scalar negation value.
     %a = not %b : i32
+    ```
+  }];
+}
+
+def RedAndOp : BtorUnaryOp<"redand"> {
+  let summary = "integer reduction with and operator";
+  let description = [{
+    Syntax:
+
+    The `redand` operation computes the and reduction of a given value. It takes one
+    operand and returns one result of type i1. 
+
+    Example:
+
+    ```mlir
+    // Scalar redand value.
+    %a = redand %b : i32
     ```
   }];
 }

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -13,6 +13,54 @@ include "BtorDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
+// btor ternary integer ops definitions
+//===----------------------------------------------------------------------===//
+
+def IteOp : Btor_Op<"ite", [NoSideEffect,
+    AllTypesMatch<["true_value", "false_value", "result"]>]
+    #ElementwiseMappable.traits> {
+    
+    let summary = "integer if-then-else operation";
+    let description = [{
+        This operation takes a condition and two integer 
+        arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.ite %cond, %true, %false : i32
+        ```
+    }];
+
+  let arguments = (ins BoolLike:$condition,
+                      SignlessIntegerLike:$true_value,
+                      SignlessIntegerLike:$false_value);
+  let results = (outs AnyType:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$condition, "Value":$trueValue, "Value":$falseValue),
+     [{
+       $_state.addOperands({condition, trueValue, falseValue});
+       $_state.addTypes(trueValue.getType());
+      }]>
+    ];
+  
+  let extraClassDeclaration = [{
+    Value getCondition() { return condition(); }
+    Value getTrueValue() { return true_value(); }
+    Value getFalseValue() { return false_value(); }
+  }];
+
+  let parser = [{
+    return parseIteOp(parser, result);
+  }];
+
+  let printer = [{
+    return printIteOp(p, this);
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // btor binary integer ops definitions
 //===----------------------------------------------------------------------===//
 
@@ -38,7 +86,7 @@ class BtorArithmeticOp<string mnemonic, list<OpTrait> traits = []> :
 // each of these is required to be of the same type.
 //  The custom assembly form of the operation is as follows
 //
-//     <op>i %0, %1 : i32
+//     <op> %0, %1 : i32
 class BtorBinaryOp<string mnemonic, list<OpTrait> traits = []> :
     BtorArithmeticOp<mnemonic, traits>,
     Arguments<(ins SignlessIntegerLike:$lhs, SignlessIntegerLike:$rhs)> {

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -169,26 +169,6 @@ def XnorOp : BtorBinaryOp<"xnor", [Commutative]> {
     }];
 }
 
-def BadOp : Btor_Op<"bad"> {
-    let summary = "btor assertion";
-    let description = [{
-        This operation takes one boolean argument and terminates
-        the program if the argument is false.
-
-        Example:
-        
-        ```mlir
-        %0 = constant 1 : i1
-        // Apply the bad operation to %0
-        btor.bad %0
-        ```
-    }];
-
-    let arguments = (ins I1:$arg);
-
-    let assemblyFormat = "$arg attr-dict";
-}
-
 def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
      TypesMatchWith<"result type has i1 element type and same shape as operands",
     "lhs", "result", "getI1SameShape($_self)">] # ElementwiseMappable.traits> {
@@ -249,6 +229,19 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
 
   let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
 } 
+
+def SRemOp : BtorBinaryOp<"srem", [Commutative]> {
+    let summary = "integer binary signed remainder operation";
+    let description = [{
+        This operation takes two integer arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.srem %lhs, %rhs : i32
+        ```
+    }];
+}
 
 //===----------------------------------------------------------------------===//
 // btor unary integer ops definitions
@@ -337,6 +330,26 @@ def RedAndOp : BtorUnaryOp<"redand"> {
     %a = btor.redand %b : i32
     ```
   }];
+}
+
+def BadOp : Btor_Op<"bad"> {
+    let summary = "btor assertion";
+    let description = [{
+        This operation takes one boolean argument and terminates
+        the program if the argument is false.
+
+        Example:
+        
+        ```mlir
+        %0 = constant 1 : i1
+        // Apply the bad operation to %0
+        btor.bad %0
+        ```
+    }];
+
+    let arguments = (ins I1:$arg);
+
+    let assemblyFormat = "$arg attr-dict";
 }
 
 #endif // BTOR_OPS


### PR DESCRIPTION
Here are the operators in `btor2`:
- completed rows are marked `yes` in the `Done` column
- In a row marked `no`, the ops with a strike through have been completed

#### Indexed Operators

| Operator            | Description               | Signature                 | Done                 |
| ------------------- | ------------------------- | ------------------------- | ------------------------- |
| `[su]ext w`         | (un)signed extension      | `B_[n] -> B_[n+w]`        |`no`         |
| `slice u l`         | extraction, `n > u >= l`  | `B_[n] -> B_[u-l+1]`      |`no`         |

#### Unary Operators

| Operator                    | Description       | Signature                 | Done                 |
| --------------------------- | ----------------- | ------------------------- | ------------------------- |
| `not`                       | bit-wise          | `B_[n] -> B_[n]`          |`yes`         |
| `inc`, `dec`, `neg`         | arithmetic        | `B_[n] -> B_[n]`          |`yes`         |
| `redand`, `redor`, `redxor` | reduction         | `B_[n] -> B_[1]`          |`no`         |

#### Binary Operators

| Operator                                          | Description           | Signature                  | Done                 |
| ------------------------------------------------- | --------------------- | -------------------------- | ------------------------- |
| `iff`, `implies`                                  | Boolean               | `B_[1] x B_[1] -> B_[1]`   |`no`         |
| `eq`, `neq`                                       | (dis)equality         | `S x S -> B_[1]`           |`yes`         |
| `[su]gt`, `[su]gte`, `[su]lt`, `[su]lte`          | (un)signed inequality | `B_[n] x B_[n] -> B_[1]`   |`yes`         |
| `and`, `nand`, `nor`, `or`, `xnor`, `xor`         | bit-wise              | `B_[n] x B_[n] -> B_[n]`   |`yes`         |
| `rol`, `ror`, `sll`, `sra`, `srl`                 | rotate, shift         | `B_[n] x B_[n] -> B_[n]`   |`yes`         |
| ~`add`~, ~`mul`~, ~`[su]div`~, `smod`, ~`[su]rem`~, ~`sub`~ | arithmetic            | `B_[n] x B_[n] -> B_[n]`   |`no`         |
| `[su]addo`, `sdivo`, `[su]mulo`, `[su]subo`       | overflow              | `B_[n] x B_[n] -> B_[1]`   |`no`         |
| `concat`                                          | concatenation         | `B_[n] x B_[m] -> B_[n+m]` |`no`         |
| `read`                                            | array read            | `A_[I -> E] x I -> E`      |`no`         |

#### Ternary Operators

| Operator       | Description           | Signature                          | Done                 |
| -------------- | --------------------- | ---------------------------------- | ------------------------- |
| `ite`          | conditional           | `B_[1] x B_[n] x B_[n] -> B_[n]`   |`yes`         |
| `write`        | array write           | `A_[I -> E] x I x E -> A_[I -> E]` |`no`         |