### PR TITLE
Implement lowering patterns

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -305,19 +305,6 @@ def UDivOp : BtorBinaryOp<"udiv"> {
     }];
 }
 
-def UDivOverflowOp : BtorBinaryDifferentResultTypeOp<"udivo"> {
-    let summary = "unsigned integer division with overflow flag";
-    let description = [{
-        This operation takes two integer arguments and returns an integer.
-
-        Example:
-        
-        ```mlir
-        %res = btor.udivo %lhs, %rhs : i32
-        ```
-    }];  
-}
-
 def OrOp : BtorBinaryOp<"or", [Commutative]> {
     let summary = "integer binary and operation";
     let description = [{
@@ -456,6 +443,36 @@ def CmpOp : Btor_Op<"cmp", [NoSideEffect, SameTypeOperands,
 
   let assemblyFormat = "$predicate `,` $lhs `,` $rhs attr-dict `:` type($lhs)";
 } 
+
+def IffOp : BtorBinaryOp<"iff"> {
+    let summary = "integer if-and-only-if operation";
+    let description = [{
+        This operation takes two i1 arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.ror %lhs, %rhs : i1
+        ```
+    }];
+
+    let arguments = (ins I1:$lhs, I1:$rhs);
+}
+
+def ImpliesOp : BtorBinaryOp<"implies"> {
+    let summary = "integer implication operation";
+    let description = [{
+        This operation takes two i1 arguments and returns an integer.
+
+        Example:
+        
+        ```mlir
+        %res = btor.ror %lhs, %rhs : i1
+        ```
+    }];
+    
+    let arguments = (ins I1:$lhs, I1:$rhs);
+}
 
 def ShiftLLOp : BtorBinaryOp<"sll"> {
     let summary = "integer left logical shift binary operation";

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -624,7 +624,7 @@ class BtorUnaryOp<string mnemonic, list<OpTrait> traits = []> :
   }];
 
   let parser = [{
-    return impl::parseOneResultSameOperandTypeOp(parser, result);
+    return parseUnaryOp(parser, result);
   }];
 }
 
@@ -711,6 +711,46 @@ def RedAndOp : BtorUnaryOp<"redand"> {
     %a = btor.redand %b : i32
     ```
   }];
+
+  let results = (outs BoolLike);
+}
+
+def RedOrOp : BtorUnaryOp<"redor"> {
+  let summary = "integer reduction with or operator";
+  let description = [{
+    Syntax:
+
+    This operation computes the or reduction of a given value. It takes one
+    operand and returns one result of type i1. 
+
+    Example:
+
+    ```mlir
+    // Scalar redand value.
+    %a = btor.redand %b : i32
+    ```
+  }];
+
+  let results = (outs BoolLike);
+}
+
+def RedXorOp : BtorUnaryOp<"redxor"> {
+  let summary = "integer reduction with and operator";
+  let description = [{
+    Syntax:
+
+    This operation computes the xor reduction of a given value. It takes one
+    operand and returns one result of type i1. 
+
+    Example:
+
+    ```mlir
+    // Scalar redand value.
+    %a = btor.redand %b : i32
+    ```
+  }];
+
+  let results = (outs BoolLike);
 }
 
 def BadOp : Btor_Op<"bad"> {

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -13,6 +13,74 @@ include "BtorDialect.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
+// btor integer bit cast ops definitions
+//===----------------------------------------------------------------------===//
+
+// Base class for Btor Cast operations Requires a single operand and result. 
+class Btor_CastOp<string mnemonic, TypeConstraint From, TypeConstraint To,
+                   list<OpTrait> traits = []> :
+    Btor_Op<mnemonic, traits # [SameOperandsAndResultShape]>,
+    Arguments<(ins From:$in)>,
+    Results<(outs To:$out)> {
+  let builders = [
+    OpBuilder<(ins "Value":$source, "Type":$destType), [{
+      impl::buildCastOp($_builder, $_state, source, destType);
+    }]>
+  ];
+
+  let assemblyFormat = "$in attr-dict `:` type($in) `to` type($out)";
+}
+
+def SignlessFixedWidthIntegerLike : TypeConstraint<Or<[
+        AnySignlessInteger.predicate,
+        VectorOf<[AnySignlessInteger]>.predicate,
+        TensorOf<[AnySignlessInteger]>.predicate]>,
+    "signless-fixed-width-integer-like">;
+
+// Cast from an integer type to another integer type.
+class BtorCastOp<string mnemonic, list<OpTrait> traits = []> :
+    Btor_CastOp<mnemonic, SignlessFixedWidthIntegerLike,
+                          SignlessFixedWidthIntegerLike>;
+
+
+def UExtOp : BtorCastOp<"uext"> {
+  let summary = "integer zero extension operation";
+  let description = [{
+    The integer zero extension operation takes an integer input of
+    width M and an integer destination type of width N. The destination
+    bit-width must be larger than the input bit-width (N > M).
+    The top-most (N - M) bits of the output are filled with zeros.
+
+    Example:
+
+    ```mlir
+      %2 = btor.uext %1 : i3 to i6
+    ```
+  }];
+
+  let verifier = [{ return verifyExtOp<IntegerType>(*this); }];
+}
+
+def SExtOp : BtorCastOp<"sext"> {
+  let summary = "integer zero extension operation";
+  let description = [{
+    The integer zero extension operation takes an integer input of
+    width M and an integer destination type of width N. The destination
+    bit-width must be larger than the input bit-width (N > M).
+    The top-most (N - M) bits of the output are filled with
+    copies of the most-significant bit of the input.
+
+    Example:
+
+    ```mlir
+      %2 = btor.sext %1 : i3 to i6
+    ```
+  }];
+
+  let verifier = [{ return verifyExtOp<IntegerType>(*this); }];
+}
+
+//===----------------------------------------------------------------------===//
 // btor ternary integer ops definitions
 //===----------------------------------------------------------------------===//
 

--- a/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
+++ b/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
@@ -68,6 +68,8 @@ using UMulOverflowOpLowering =
       VectorConvertToLLVMPattern<btor::UMulOverflowOp, LLVM::UMulWithOverflowOp>;
 // using SDivOverflowOpLowering = 
 //       VectorConvertToLLVMPattern<btor::SDivOverflowOp, LLVM::SDivWithOverflowOp>;
+using UExtOpLowering = VectorConvertToLLVMPattern<btor::UExtOp, LLVM::ZExtOp>;
+using SExtOpLowering = VectorConvertToLLVMPattern<btor::SExtOp, LLVM::SExtOp>;
 using IteOpLowering = VectorConvertToLLVMPattern<btor::IteOp, LLVM::SelectOp>;
 using XnorOpLowering = ConvertNotOpToBtorPattern<btor::XnorOp, btor::XOrOp>;
 using NandOpLowering = ConvertNotOpToBtorPattern<btor::NandOp, btor::AndOp>;
@@ -389,26 +391,27 @@ void BtorToLLVMLoweringPass::runOnOperation() {
 
     /// Configure conversion to lower out btor; Anything else is fine.
     // indexed operators
+    target.addIllegalOp<btor::UExtOp, btor::SExtOp>();
 
     /// unary operators
-    target.addIllegalOp<btor::NotOp, btor::IncOp, btor::DecOp, btor::NegOp>(); // not 
-    target.addIllegalOp<btor::BadOp, btor::ConstantOp>(); // done
+    target.addIllegalOp<btor::NotOp, btor::IncOp, btor::DecOp, btor::NegOp>();
+    target.addIllegalOp<btor::BadOp, btor::ConstantOp>();
 
     /// binary operators
     // logical 
-    target.addIllegalOp<btor::IffOp, btor::ImpliesOp, btor::CmpOp>(); // done
-    target.addIllegalOp<btor::AndOp, btor::NandOp, btor::NorOp, btor::OrOp>(); // done
-    target.addIllegalOp<btor::XnorOp, btor::XOrOp, btor::RotateLOp, btor::RotateROp>(); // done
-    target.addIllegalOp<btor::ShiftLLOp, btor::ShiftRAOp, btor::ShiftRLOp>(); // done
+    target.addIllegalOp<btor::IffOp, btor::ImpliesOp, btor::CmpOp>();
+    target.addIllegalOp<btor::AndOp, btor::NandOp, btor::NorOp, btor::OrOp>();
+    target.addIllegalOp<btor::XnorOp, btor::XOrOp, btor::RotateLOp, btor::RotateROp>();
+    target.addIllegalOp<btor::ShiftLLOp, btor::ShiftRAOp, btor::ShiftRLOp>();
     // arithmetic
-    target.addIllegalOp<btor::AddOp, btor::MulOp, btor::SDivOp, btor::UDivOp>(); // done
+    target.addIllegalOp<btor::AddOp, btor::MulOp, btor::SDivOp, btor::UDivOp>();
     target.addIllegalOp<btor::SModOp, btor::SRemOp, btor::URemOp, btor::SubOp>(); // srem, urem, sub
     target.addIllegalOp<btor::SAddOverflowOp, btor::UAddOverflowOp, btor::SDivOverflowOp>(); // saddo, uaddo
-    target.addIllegalOp<btor::SMulOverflowOp, btor::UMulOverflowOp>(); // done
-    target.addIllegalOp<btor::SSubOverflowOp, btor::USubOverflowOp>(); // done
+    target.addIllegalOp<btor::SMulOverflowOp, btor::UMulOverflowOp>();
+    target.addIllegalOp<btor::SSubOverflowOp, btor::USubOverflowOp>();
 
     /// ternary operators
-    target.addIllegalOp<btor::IteOp>(); // ite
+    target.addIllegalOp<btor::IteOp>();
 
     if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
         signalPassFailure();
@@ -455,7 +458,9 @@ void mlir::btor::populateBtorToLLVMConversionPatterns(LLVMTypeConverter &convert
     NorOpLowering,
     IncOpLowering,
     DecOpLowering,
-    NegOpLowering
+    NegOpLowering,
+    UExtOpLowering,
+    SExtOpLowering
   >(converter);       
 }
 

--- a/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
+++ b/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
@@ -31,9 +31,6 @@ class ConvertNotOpToBtorPattern : public ConvertOpToLLVMPattern<SourceOp> {
             rewriter.replaceOpWithNewOp<btor::NotOp>(op, baseOp);
 
             return success();
-    // return LLVM::detail::vectorOneToOneRewrite(
-    //     op, TargetOp::getOperationName(), adaptor.getOperands(),
-    //     *this->getTypeConverter(), rewriter);
   }
 };
 

--- a/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
+++ b/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
@@ -71,6 +71,9 @@ using UMulOverflowOpLowering =
 using UExtOpLowering = VectorConvertToLLVMPattern<btor::UExtOp, LLVM::ZExtOp>;
 using SExtOpLowering = VectorConvertToLLVMPattern<btor::SExtOp, LLVM::SExtOp>;
 using IteOpLowering = VectorConvertToLLVMPattern<btor::IteOp, LLVM::SelectOp>;
+using RedOrOpLowering = VectorConvertToLLVMPattern<btor::RedOrOp, LLVM::vector_reduce_or>;
+using RedXorOpLowering = VectorConvertToLLVMPattern<btor::RedXorOp, LLVM::vector_reduce_xor>;
+using RedAndOpLowering = VectorConvertToLLVMPattern<btor::RedAndOp, LLVM::vector_reduce_and>;
 using XnorOpLowering = ConvertNotOpToBtorPattern<btor::XnorOp, btor::XOrOp>;
 using NandOpLowering = ConvertNotOpToBtorPattern<btor::NandOp, btor::AndOp>;
 using NorOpLowering = ConvertNotOpToBtorPattern<btor::NorOp, btor::OrOp>;
@@ -395,6 +398,7 @@ void BtorToLLVMLoweringPass::runOnOperation() {
 
     /// unary operators
     target.addIllegalOp<btor::NotOp, btor::IncOp, btor::DecOp, btor::NegOp>();
+    target.addIllegalOp<btor::RedAndOp, btor::RedXorOp, btor::RedOrOp>();
     target.addIllegalOp<btor::BadOp, btor::ConstantOp>();
 
     /// binary operators
@@ -459,6 +463,9 @@ void mlir::btor::populateBtorToLLVMConversionPatterns(LLVMTypeConverter &convert
     IncOpLowering,
     DecOpLowering,
     NegOpLowering,
+    RedOrOpLowering,
+    RedAndOpLowering,
+    RedXorOpLowering,
     UExtOpLowering,
     SExtOpLowering
   >(converter);       

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -26,6 +26,19 @@ static void printBtorUnaryOp(Operation *op, OpAsmPrinter &p) {
   p << " : " << op->getOperand(0).getType();
 }
 
+static ParseResult parseUnaryOp(OpAsmParser &parser, OperationState &result) {  
+  Type operandType, resultType;
+  SmallVector<OpAsmParser::OperandType, 1> operands;
+  if (parser.parseOperandList(operands, /*requiredOperandCount=*/1) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonType(operandType))
+    return failure();
+  
+  result.addTypes(parser.getBuilder().getI1Type());
+  return parser.resolveOperands(operands, {operandType},
+                                parser.getNameLoc(), result.operands);
+}
+
 /// A custom binary operation printer that omits the "btor." prefix from the
 /// operation names.
 static void printBtorBinaryOp(Operation *op, OpAsmPrinter &p) {

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -10,6 +10,7 @@
 #include "Dialect/Btor/IR/BtorOps.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/TypeUtilities.h"
 
 using namespace mlir;
 using namespace mlir::btor;
@@ -158,6 +159,22 @@ static void printBtorBinaryDifferentResultTypeOp(Operation *op, OpAsmPrinter &p)
 
   // Now we can output only one type for all operands and the result.
   p << " : " << op->getResult(0).getType();
+}
+
+//===----------------------------------------------------------------------===//
+// Extension Operations
+//===----------------------------------------------------------------------===//
+
+template <typename ValType, typename Op>
+static LogicalResult verifyExtOp(Op op) {
+  Type srcType = getElementTypeOrSelf(op.in().getType());
+  Type dstType = getElementTypeOrSelf(op.getType());
+
+  if (srcType.cast<ValType>().getWidth() >= dstType.cast<ValType>().getWidth())
+    return op.emitError("result type ")
+           << dstType << " must be wider than operand type " << srcType;
+
+  return success();
 }
 
 #define GET_OP_CLASSES


### PR DESCRIPTION
From the list of `btor2` operations that we are to implement, only the operations below are awaiting implementation:

#### Indexed Operators

| Operator            | Description               | Signature                 |
| ------------------- | ------------------------- | ------------------------- |
| `slice u l`         | extraction, `n > u >= l`  | `B_[n] -> B_[u-l+1]` 

#### Binary Operators

| Operator                                          | Description           | Signature                  |
| ------------------------------------------------- | --------------------- | -------------------------- |
| `smod`  | arithmetic            | `B_[n] x B_[n] -> B_[n]`   |
| `sdivo`   | overflow              | `B_[n] x B_[n] -> B_[1]`   |
| `concat`                                          | concatenation         | `B_[n] x B_[m] -> B_[n+m]` |
| `read`                                            | array read            | `A_[I -> E] x I -> E`      |

#### Ternary Operators

| Operator       | Description           | Signature                          | 
| -------------- | --------------------- | ---------------------------------- |
| `write`        | array write           | `A_[I -> E] x I x E -> A_[I -> E]` |