### PR TITLE
feat: add assume and assert

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -816,7 +816,7 @@ def RedXorOp : BtorUnaryOp<"redxor"> {
   let results = (outs BoolLike);
 }
 
-def BadOp : Btor_Op<"bad"> {
+def AssertOp : Btor_Op<"assert"> {
     let summary = "btor assertion";
     let description = [{
         This operation takes one boolean argument and terminates
@@ -826,14 +826,14 @@ def BadOp : Btor_Op<"bad"> {
         
         ```mlir
         %0 = constant 1 : i1
-        // Apply the bad operation to %0
-        btor.bad %0
+        // Apply the assert operation to %0
+        btor.assert ( %0 )
         ```
     }];
 
     let arguments = (ins I1:$arg);
 
-    let assemblyFormat = "$arg attr-dict";
+    let assemblyFormat = "`(` $arg `)` attr-dict";
 }
 
 def ConstantOp : Btor_Op<"const", [ConstantLike, NoSideEffect]> {
@@ -873,6 +873,26 @@ def ConstantOp : Btor_Op<"const", [ConstantLike, NoSideEffect]> {
   }];
 
   let hasFolder = 1;
+}
+
+def AssumeOp : Btor_Op<"assume"> {
+    let summary = "btor assumption";
+    let description = [{
+        This operation takes one boolean argument and assumes 
+        it holds for the program.
+
+        Example:
+        
+        ```mlir
+        %0 = constant 1 : i1
+        // Apply the assume operation to %0
+        btor.assume ( %0 )
+        ```
+    }];
+
+    let arguments = (ins I1:$arg);
+
+    let assemblyFormat = "`(` $arg `)` attr-dict";
 }
 
 #endif // BTOR_OPS

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -1,19 +1,18 @@
 // RUN: btor2mlir-opt %s | btor2mlir-opt | FileCheck %s
 
 module {
-    // CHECK-LABEL: func @bar()
-    func @bar() {
-        %0 = constant 7 : i3
-        // CHECK: %{{.*}} = constant {{.*}} : i3
-        %1 = constant 3 : i3
-        // CHECK: %{{.*}} = btor.add %{{.*}}, %{{.*}} : i3
-        %2 = btor.add %0, %1 : i3
-        // CHECK: %{{.*}} = btor.mul %{{.*}}, %{{.*}} : i3
-        %3 = btor.mul %0, %2 : i3
-        // CHECK: %{{.*}} = btor.cmp %{{.*}}, %{{.*}} : i3
-        %4 = btor.cmp "ne", %3, %2 : i3
-        // CHECK: %{{.*}} = btor.bad %{{.*}}
-        btor.bad %4
-        return
+    func @next( %arg0: i3, %arg1: i3 ) -> (i3, i3) {
+        // create assumption
+        %cmp_ne = btor.cmp "ne", %arg0, %arg1 : i3
+        btor.assume ( %cmp_ne )
+        // apply transition relation
+        %c_0 = btor.const 1 : i3
+        %add_1 = btor.add %arg0, %c_0 : i3
+        %sub_1 = btor.sub %arg1, %c_0 : i3
+        // create assertion
+        %bad = btor.cmp "ne", %add_1, %sub_1 : i3
+        %notbad = btor.not %bad : i1
+        btor.assert ( %notbad )
+        return %add_1, %sub_1 : i3, i3
     }
 }


### PR DESCRIPTION
We can represent our verification conditions in the following way:
### With comments 
```
module {
    func @next( %arg0: i3, %arg1: i3 ) -> (i3, i3) {
        // create assumption
        %cmp_ne = btor.cmp "ne", %arg0, %arg1 : i3
        btor.assume ( %cmp_ne )
        // apply transition relation
        %c_0 = btor.const 1 : i3
        %add_1 = btor.add %arg0, %c_0 : i3
        %sub_1 = btor.sub %arg1, %c_0 : i3
        // create assertion
        %bad = btor.cmp "ne", %add_1, %sub_1 : i3
        %notbad = btor.not %bad : i1
        btor.assert ( %notbad )
        return %add_1, %sub_1 : i3, i3
    }
}
```
### Without comments
```
module  {
  func @next(%arg0: i3, %arg1: i3) -> (i3, i3) {
    %0 = btor.cmp ne, %arg0, %arg1 : i3
    btor.assume(%0)
    %1 = btor.const 1 : i3
    %2 = btor.add %arg0, %1 : i3
    %3 = btor.sub %arg1, %1 : i3
    %4 = btor.cmp ne, %2, %3 : i3
    %5 = btor.not %4 : i1
    btor.assert(%5)
    return %2, %3 : i3, i3
  }
}
```