### PR TITLE
feat: add init and input

### DIFF
--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -156,7 +156,6 @@ def SliceOp : Btor_Op<"slice", [NoSideEffect,
                    "Value":$lower_bound),
      [{
        $_state.addOperands({in, upper_bound, lower_bound});
-       //$_state.addTypes(trueValue.getType());
       }]>
     ];
 
@@ -898,20 +897,40 @@ def AssumeOp : Btor_Op<"assume"> {
 def InputOp : Btor_Op<"input"> {
     let summary = "btor input";
     let description = [{
-        This operation takes no argument and returns a value
-        of type: SignlessIntegerLike
+        This operation takes an input number and a
+        SignlessIntegerLike, then returns the 
+        received SignlessIntegerLike
 
         Example:
         
         ```mlir
         // invoke the input operation to %0
-        %0 = btor.input : i3
+        %0 = btor.input 15, %some_i3_value : i3
         ```
+
+        In the example above, 15 gets interpreted as an
+        i64 integer, while %some_i3_value is expected 
+        to be of type i3. 
     }];
 
-    let results = (outs SignlessIntegerLike:$res);
+    let arguments = (ins AnyAttr:$id, SignlessIntegerLike:$value);
+    let results = (outs SignlessIntegerLike:$result);
 
-    let assemblyFormat = "attr-dict `:` type($res)";
+    let builders = [
+        OpBuilder<(ins "Value":$value),
+        [{
+            $_state.addOperands({value});
+            $_state.addTypes(value.getType());
+        }]>
+    ];
+
+    let printer = [{
+      return printInputOp(p, *this);
+    }];
+
+    let parser = [{
+      return parseInputOp(parser, result);
+    }];
 }
 
 #endif // BTOR_OPS

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -895,4 +895,23 @@ def AssumeOp : Btor_Op<"assume"> {
     let assemblyFormat = "`(` $arg `)` attr-dict";
 }
 
+def InputOp : Btor_Op<"input"> {
+    let summary = "btor input";
+    let description = [{
+        This operation takes no argument and returns a value
+        of type: SignlessIntegerLike
+
+        Example:
+        
+        ```mlir
+        // invoke the input operation to %0
+        %0 = btor.input : i3
+        ```
+    }];
+
+    let results = (outs SignlessIntegerLike:$res);
+
+    let assemblyFormat = "attr-dict `:` type($res)";
+}
+
 #endif // BTOR_OPS

--- a/lib/Dialect/Btor/IR/BtorOps.cpp
+++ b/lib/Dialect/Btor/IR/BtorOps.cpp
@@ -258,5 +258,39 @@ static LogicalResult verifyConcatOp(Op op) {
   return success();
 }
 
+//===----------------------------------------------------------------------===//
+// Input Operation
+//===----------------------------------------------------------------------===//
+
+static void printInputOp(OpAsmPrinter &p, mlir::btor::InputOp &op) {
+    p << " "  << op.value() << " : " << op->getOperand(0).getType();
+    p << " ";
+    p.printOptionalAttrDict(op->getAttrs());
+}
+
+static ParseResult parseInputOp(OpAsmParser &parser,OperationState &result) {  
+    SmallVector<OpAsmParser::OperandType> ops;
+    NamedAttrList attrs;
+    Attribute idAttr;
+    Type type;
+
+    if (parser.parseAttribute(idAttr, "id", attrs) ||
+        parser.parseComma() ||
+        parser.parseOperandList(ops, 1) ||
+        parser.parseOptionalAttrDict(attrs) || 
+        parser.parseColonType(type) ||
+        parser.resolveOperands(ops, type, result.operands)
+        )
+        return failure();
+
+    if (!idAttr.isa<mlir::IntegerAttr>())
+        return parser.emitError(parser.getNameLoc(),
+                                "expected integer id attribute");
+
+    result.attributes = attrs;
+    result.addTypes({type});
+  return success();
+}
+
 #define GET_OP_CLASSES
 #include "Dialect/Btor/IR/BtorOps.cpp.inc"

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -1,15 +1,16 @@
 // RUN: btor2mlir-opt %s | btor2mlir-opt | FileCheck %s
 
 module {
-    // two latches, arg_{0, 1}, and the two inputs
-    // we want them to be equal to, arg_{2, 3}
-    func @init( %arg0: i3, %arg1: i3, %arg2: i3, %arg3: i3 ) -> (i3,i3) {
-        return %arg2, %arg3 : i3, i3
+    func @init( ) -> (i3,i3) {
+        %0 = btor.const 0 : i3
+        %1 = btor.const 0 : i3
+        return %0, %1 : i3, i3
     }
 
-    func @in_i() -> (i3, i3) {
-        %0 = btor.input : i3
-        %1 = btor.input : i3
+    func @input() -> (i3, i3) {
+        %const = btor.const 7 : i3
+        %0 = btor.input 0, %const :  i3
+        %1 = btor.input 9, %const : i3
         return %0, %1 : i3, i3
     }
 

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -1,6 +1,18 @@
 // RUN: btor2mlir-opt %s | btor2mlir-opt | FileCheck %s
 
 module {
+    // two latches, arg_{0, 1}, and the two inputs
+    // we want them to be equal to, arg_{2, 3}
+    func @init( %arg0: i3, %arg1: i3, %arg2: i3, %arg3: i3 ) -> (i3,i3) {
+        return %arg2, %arg3 : i3, i3
+    }
+
+    func @in_i() -> (i3, i3) {
+        %0 = btor.input : i3
+        %1 = btor.input : i3
+        return %0, %1 : i3, i3
+    }
+
     func @next( %arg0: i3, %arg1: i3 ) -> (i3, i3) {
         // create assumption
         %cmp_ne = btor.cmp "ne", %arg0, %arg1 : i3


### PR DESCRIPTION
We can represent our verification conditions in the following way:
### Before Pretty Print
```
module {
    func @init( ) -> (i3,i3) {
        %0 = btor.const 0 : i3
        %1 = btor.const 0 : i3
        return %0, %1 : i3, i3
    }

    func @input() -> (i3, i3) {
        %const = btor.const 7 : i3
        %0 = btor.input 0, %const :  i3
        %1 = btor.input 9, %const : i3
        return %0, %1 : i3, i3
    }
}
```
### Pretty Print
```
module  {
  func @init() -> (i3, i3) {
    %0 = btor.const 0 : i3
    %1 = btor.const 0 : i3
    return %0, %1 : i3, i3
  }
  func @input() -> (i3, i3) {
    %0 = btor.const -1 : i3
    %1 = btor.input %0 : i3  {id = 0 : i64}
    %2 = btor.input %0 : i3  {id = 9 : i64}
    return %1, %2 : i3, i3
  }
}
```