### PR TITLE
feat: add main function during translation

### DIFF
--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -86,6 +86,7 @@ class Deserialize {
 
   OwningOpRef<FuncOp> buildInitFunction();
   OwningOpRef<FuncOp> buildNextFunction();
+  OwningOpRef<FuncOp> buildMainFunction(const OwningModuleRef &module);
   
  private: 
 ///===----------------------------------------------------------------------===//


### PR DESCRIPTION
The main idea here is to create the function,`main`, in the translation pass. There are a few benefits to doing this:
1. We get to generate the sequential logic at the same time as our combinational logic
2. We need only use the built-in conversion passes to get `llvm-ir` from our `btor-mlir` representation

Here is a set of commands that show how we can go from `btor2` to `llvm-ir`
1. Start with the `btor2` file below
```
1 sort bitvec 4
2 zero 1
3 state 1
4 init 1 3 2
5 one 1
6 add 1 3 5
7 next 1 3 6
8 ones 1
9 sort bitvec 1
10 eq 9 3 8
11 bad 10
```
2. Calling `./debug/bin/btor2mlir-translate --import-btor` on the file above gives us:
```
module  {
  func @init() -> i4 {
    %0 = btor.const 0 : i4
    return %0 : i4
  }
  func @next(%arg0: i4) -> i4 {
    %0 = btor.const 1 : i4
    %1 = btor.add %arg0, %0 : i4
    %2 = btor.const -1 : i4
    %3 = btor.cmp eq, %arg0, %2 : i4
    btor.assert_not(%3)
    return %1 : i4
  }
  func @main() {
    %0 = call @init() : () -> i4
    br ^bb1(%0 : i4)
  ^bb1(%1: i4):  // 2 preds: ^bb0, ^bb1
    %2 = call @next(%1) : (i4) -> i4
    br ^bb1(%2 : i4)
  }
}
```
3. Calling `./debug/bin/btor2mlir-opt --convert-btor-to-llvm --convert-std-to-llvm` on the file above then gives us:
```
module attributes {llvm.data_layout = ""}  {
  llvm.func @abort()
  llvm.func @init() -> i4 {
    %0 = llvm.mlir.constant(0 : i4) : i4
    llvm.return %0 : i4
  }
  llvm.func @next(%arg0: i4) -> i4 {
    %0 = llvm.mlir.constant(1 : i4) : i4
    %1 = llvm.add %arg0, %0  : i4
    %2 = llvm.mlir.constant(-1 : i4) : i4
    %3 = llvm.icmp "eq" %arg0, %2 : i4
    %4 = llvm.mlir.constant(true) : i1
    %5 = llvm.xor %3, %4  : i1
    llvm.cond_br %5, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    llvm.return %1 : i4
  ^bb2:  // pred: ^bb0
    llvm.call @abort() : () -> ()
    llvm.unreachable
  }
  llvm.func @main() {
    %0 = llvm.call @init() : () -> i4
    llvm.br ^bb1(%0 : i4)
  ^bb1(%1: i4):  // 2 preds: ^bb0, ^bb1
    %2 = llvm.call @next(%1) : (i4) -> i4
    llvm.br ^bb1(%2 : i4)
  }
}
```
4 Finally, we get `llvm-ir` by calling: `./debug/bin/btor2mlir-translate --mlir-to-llvmir` on the file above
```
; ModuleID = 'LLVMDialectModule'
source_filename = "LLVMDialectModule"

declare i8* @malloc(i64)

declare void @free(i8*)

declare void @abort()

define i4 @init() !dbg !3 {
  ret i4 0, !dbg !7
}

define i4 @next(i4 %0) !dbg !9 {
  %2 = add i4 %0, 1, !dbg !10
  %3 = icmp eq i4 %0, -1, !dbg !12
  %4 = xor i1 %3, true, !dbg !13
  br i1 %4, label %5, label %6, !dbg !14

5:                                                ; preds = %1
  ret i4 %2, !dbg !15

6:                                                ; preds = %1
  call void @abort(), !dbg !16
  unreachable, !dbg !17
}

define void @main() !dbg !18 {
  %1 = call i4 @init(), !dbg !19
  br label %2, !dbg !21

2:                                                ; preds = %2, %0
  %3 = phi i4 [ %4, %2 ], [ %1, %0 ]
  %4 = call i4 @next(i4 %3), !dbg !22
  br label %2, !dbg !23
}

!llvm.dbg.cu = !{!0}
!llvm.module.flags = !{!2}

!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "mlir", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
!1 = !DIFile(filename: "LLVMDialectModule", directory: "/")
!2 = !{i32 2, !"Debug Info Version", i32 3}
!3 = distinct !DISubprogram(name: "init", linkageName: "init", scope: null, file: !4, line: 3, type: !5, scopeLine: 3, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !6)
!4 = !DIFile(filename: "<stdin>", directory: "/home/jetafese/btor2mlir-1")
!5 = !DISubroutineType(types: !6)
!6 = !{}
!7 = !DILocation(line: 5, column: 5, scope: !8)
!8 = !DILexicalBlockFile(scope: !3, file: !4, discriminator: 0)
!9 = distinct !DISubprogram(name: "next", linkageName: "next", scope: null, file: !4, line: 7, type: !5, scopeLine: 7, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !6)
!10 = !DILocation(line: 9, column: 10, scope: !11)
!11 = !DILexicalBlockFile(scope: !9, file: !4, discriminator: 0)
!12 = !DILocation(line: 11, column: 10, scope: !11)
!13 = !DILocation(line: 13, column: 10, scope: !11)
!14 = !DILocation(line: 14, column: 5, scope: !11)
!15 = !DILocation(line: 16, column: 5, scope: !11)
!16 = !DILocation(line: 18, column: 5, scope: !11)
!17 = !DILocation(line: 19, column: 5, scope: !11)
!18 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !4, line: 21, type: !5, scopeLine: 21, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !6)
!19 = !DILocation(line: 22, column: 10, scope: !20)
!20 = !DILexicalBlockFile(scope: !18, file: !4, discriminator: 0)
!21 = !DILocation(line: 23, column: 5, scope: !20)
!22 = !DILocation(line: 25, column: 10, scope: !20)
!23 = !DILocation(line: 26, column: 5, scope: !20)
```

