### PR TITLE
feat: inline init and next into main function

### DIFF
--- a/include/Target/Btor/BtorToBtorIRTranslation.h
+++ b/include/Target/Btor/BtorToBtorIRTranslation.h
@@ -84,9 +84,7 @@ class Deserialize {
     return m_cache.count(id) != 0;
   }
 
-  OwningOpRef<FuncOp> buildInitFunction();
-  OwningOpRef<FuncOp> buildNextFunction();
-  OwningOpRef<FuncOp> buildMainFunction(const OwningModuleRef &module);
+  OwningOpRef<FuncOp> buildMainFunction();
   
  private: 
 ///===----------------------------------------------------------------------===//
@@ -132,6 +130,9 @@ class Deserialize {
   Operation * createMLIR(const Btor2Line *line, 
                         const SmallVector<Value> &kids,
                         const SmallVector<unsigned> &arguments);
+  std::vector<Value> buildInitFunction(const std::vector<Type> &returnTypes);
+  std::vector<Value> buildNextFunction(const std::vector<Type> &returnTypes, 
+                                    Block *body);
 
   // Builder wrappers
   Type getIntegerTypeOf(Btor2Line * line) {


### PR DESCRIPTION
Based on prior discussion, we are creating a `main` function in the translation pass that has the `init` and `next` functions appropriately inlined. 

Here is a set of commands that show how we can go from `btor2` to `llvm-ir`
1. Start with the `btor2` file below that has 2 states:
```
1 sort bitvec 4
2 one 1
3 state 1 factorial
4 state 1 i
5 init 1 3 2
6 init 1 4 2
7 add 1 4 2
8 mul 1 3 4
9 next 1 4 7
10 next 1 3 8
11 ones 1
12 sort bitvec 1
13 eq 12 4 11
14 bad 13
15 slice 12 3 0 0
16 constd 1 3
17 ugt 12 4 16
18 and 12 17 15
19 bad 18
```
2. Calling `./debug/bin/btor2mlir-translate --import-btor` on the file above gives us:
```
module  {
  func @main() {
    %0 = btor.const 1 : i4
    br ^bb1(%0, %0 : i4, i4)
  ^bb1(%1: i4, %2: i4):  // 2 preds: ^bb0, ^bb1
    %3 = btor.const 1 : i4
    %4 = btor.add %2, %3 : i4
    %5 = btor.mul %1, %2 : i4
    %6 = btor.const -1 : i4
    %7 = btor.cmp eq, %2, %6 : i4
    btor.assert_not(%7)
    %8 = btor.const 0 : i4
    %9 = btor.const 0 : i4
    %10 = "btor.slice"(%1, %8, %9) : (i4, i4, i4) -> i1
    %11 = btor.const 3 : i4
    %12 = btor.cmp ugt, %2, %11 : i4
    %13 = btor.and %12, %10 : i1
    btor.assert_not(%13)
    br ^bb1(%5, %4 : i4, i4)
  }
}
```
3. Calling `./debug/bin/btor2mlir-opt --convert-btor-to-llvm --convert-std-to-llvm` on the file above then gives us:
```
module attributes {llvm.data_layout = ""}  {
  llvm.func @abort()
  llvm.func @main() {
    %0 = llvm.mlir.constant(1 : i4) : i4
    llvm.br ^bb1(%0, %0 : i4, i4)
  ^bb1(%1: i4, %2: i4):  // 2 preds: ^bb0, ^bb3
    %3 = llvm.mlir.constant(1 : i4) : i4
    %4 = llvm.add %2, %3  : i4
    %5 = llvm.mul %1, %2  : i4
    %6 = llvm.mlir.constant(-1 : i4) : i4
    %7 = llvm.icmp "eq" %2, %6 : i4
    %8 = llvm.mlir.constant(true) : i1
    %9 = llvm.xor %7, %8  : i1
    llvm.cond_br %9, ^bb2, ^bb4
  ^bb2:  // pred: ^bb1
    %10 = llvm.mlir.constant(0 : i4) : i4
    %11 = llvm.mlir.constant(0 : i4) : i4
    %12 = llvm.mlir.constant(4 : i4) : i4
    %13 = llvm.sub %12, %10  : i4
    %14 = llvm.lshr %1, %13  : i4
    %15 = llvm.trunc %14 : i4 to i1
    %16 = llvm.mlir.constant(3 : i4) : i4
    %17 = llvm.icmp "ugt" %2, %16 : i4
    %18 = llvm.and %17, %15  : i1
    %19 = llvm.mlir.constant(true) : i1
    %20 = llvm.xor %18, %19  : i1
    llvm.cond_br %20, ^bb3, ^bb5
  ^bb3:  // pred: ^bb2
    llvm.br ^bb1(%5, %4 : i4, i4)
  ^bb4:  // pred: ^bb1
    llvm.call @abort() : () -> ()
    llvm.unreachable
  ^bb5:  // pred: ^bb2
    llvm.call @abort() : () -> ()
    llvm.unreachable
  }
}
```
4 Finally, we get `llvm-ir` by calling: `./debug/bin/btor2mlir-translate --mlir-to-llvmir` on the file above
```
; ModuleID = 'LLVMDialectModule'
source_filename = "LLVMDialectModule"

declare i8* @malloc(i64)

declare void @free(i8*)

declare void @abort()

define void @main() !dbg !3 {
  br label %1, !dbg !7

1:                                                ; preds = %14, %0
  %2 = phi i4 [ %5, %14 ], [ 1, %0 ]
  %3 = phi i4 [ %4, %14 ], [ 1, %0 ]
  %4 = add i4 %3, 1, !dbg !9
  %5 = mul i4 %2, %3, !dbg !10
  %6 = icmp eq i4 %3, -1, !dbg !11
  %7 = xor i1 %6, true, !dbg !12
  br i1 %7, label %8, label %15, !dbg !13

8:                                                ; preds = %1
  %9 = lshr i4 %2, 4, !dbg !14
  %10 = trunc i4 %9 to i1, !dbg !15
  %11 = icmp ugt i4 %3, 3, !dbg !16
  %12 = and i1 %11, %10, !dbg !17
  %13 = xor i1 %12, true, !dbg !18
  br i1 %13, label %14, label %16, !dbg !19

14:                                               ; preds = %8
  br label %1, !dbg !20

15:                                               ; preds = %1
  call void @abort(), !dbg !21
  unreachable, !dbg !22

16:                                               ; preds = %8
  call void @abort(), !dbg !23
  unreachable, !dbg !24
}

!llvm.dbg.cu = !{!0}
!llvm.module.flags = !{!2}

!0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "mlir", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
!1 = !DIFile(filename: "LLVMDialectModule", directory: "/")
!2 = !{i32 2, !"Debug Info Version", i32 3}
!3 = distinct !DISubprogram(name: "main", linkageName: "main", scope: null, file: !4, line: 3, type: !5, scopeLine: 3, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !6)
!4 = !DIFile(filename: "<stdin>", directory: "/home/jetafese/btor2mlir-1")
!5 = !DISubroutineType(types: !6)
!6 = !{}
!7 = !DILocation(line: 5, column: 5, scope: !8)
!8 = !DILexicalBlockFile(scope: !3, file: !4, discriminator: 0)
!9 = !DILocation(line: 8, column: 10, scope: !8)
!10 = !DILocation(line: 9, column: 10, scope: !8)
!11 = !DILocation(line: 11, column: 10, scope: !8)
!12 = !DILocation(line: 13, column: 10, scope: !8)
!13 = !DILocation(line: 14, column: 5, scope: !8)
!14 = !DILocation(line: 20, column: 11, scope: !8)
!15 = !DILocation(line: 21, column: 11, scope: !8)
!16 = !DILocation(line: 23, column: 11, scope: !8)
!17 = !DILocation(line: 24, column: 11, scope: !8)
!18 = !DILocation(line: 26, column: 11, scope: !8)
!19 = !DILocation(line: 27, column: 5, scope: !8)
!20 = !DILocation(line: 29, column: 5, scope: !8)
!21 = !DILocation(line: 31, column: 5, scope: !8)
!22 = !DILocation(line: 32, column: 5, scope: !8)
!23 = !DILocation(line: 34, column: 5, scope: !8)
!24 = !DILocation(line: 35, column: 5, scope: !8)
```

