### PR TITLE
feat: __VERIFIER_error func for seahorn

### DIFF
--- a/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
+++ b/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
@@ -233,13 +233,13 @@ LogicalResult AssertNotOpLowering::matchAndRewrite(btor::AssertNotOp assertOp, O
 
     // Insert the `abort` declaration if necessary.
     auto module = assertOp->getParentOfType<ModuleOp>();
-    auto abortFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("abort");
+    auto abortFunc = module.lookupSymbol<LLVM::LLVMFuncOp>("__VERIFIER_error");
     if (!abortFunc) {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(module.getBody());
       auto abortFuncTy = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(getContext()), {});
       abortFunc = rewriter.create<LLVM::LLVMFuncOp>(rewriter.getUnknownLoc(),
-                                                    "abort", abortFuncTy);
+                                                    "__VERIFIER_error", abortFuncTy);
     }
 
     // Split block at `assert` operation.


### PR DESCRIPTION
With this change in our `--convert-btor-to-llvm` pass, we're able to run the translate the output using the `--mlir-to-llvmir` , into `file.bc`  for example. We can the use seahorn as follows:

`sea bpf --bmc=opsem file.bc -o file.smt2`

The VC's that were represented in btor-mlir should be visible in `file.smt2`