### PR TITLE
feat: Add a function that returns OwningModuleRef 

### DIFF
--- a/crab2mlir-opt/crab2mlir-opt.cpp
+++ b/crab2mlir-opt/crab2mlir-opt.cpp
@@ -9,26 +9,72 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/InitAllDialects.h"
-#include "mlir/InitAllPasses.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
+#include "mlir/Parser.h"
 #include "mlir/Support/FileUtilities.h"
-#include "mlir/Support/MlirOptMain.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 #include "Dialect/Crab/IR/CrabDialect.h"
-#include "Conversion/Passes.h"
+
+using namespace mlir;
+using namespace llvm;
+
+namespace {
+    static cl::opt<std::string> inputFilename(
+        cl::Positional, cl::desc("<input file>"), cl::init("-"));
+
+    static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
+                                                cl::value_desc("filename"),
+                                                cl::init("-"));
+}
+
+static OwningModuleRef processCrabBuffer(raw_ostream &os, 
+                                std::unique_ptr<MemoryBuffer> ownedBuffer,
+                                DialectRegistry &registry) {
+    // Tell sourceMgr about this buffer; parser will pick this up
+    SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(ownedBuffer), llvm::SMLoc());
+    // New context for our buffer
+    MLIRContext context(registry);
+    SourceMgrDiagnosticVerifierHandler sourceMgrHandler(sourceMgr, &context);
+
+    OwningModuleRef module(parseSourceFile(sourceMgr, &context));
+    if (module) {
+        module->print(os);
+        os << '\n';
+    }
+
+    return module;
+}
 
 int main(int argc, char **argv) {
-  mlir::registerAllPasses();
+    // Register our used dialects
+    mlir::DialectRegistry registry;
+    registry.insert<mlir::crab::CrabDialect>();
+    registry.insert<mlir::StandardOpsDialect>();
 
-  mlir::DialectRegistry registry;
-  registry.insert<mlir::crab::CrabDialect>();
-  registry.insert<mlir::StandardOpsDialect>();
+    // Set up needed tools
+    InitLLVM y(argc, argv);
+    cl::ParseCommandLineOptions(argc, argv);
 
-  return mlir::asMainReturnCode(
-      mlir::MlirOptMain(argc, argv, "Crab optimizer driver\n", registry));
+    // Set up the input file.
+    std::string errorMessage;
+    auto file = openInputFile(inputFilename, &errorMessage);
+    if (!file) {
+        llvm::errs() << errorMessage << "\n";
+        return EXIT_FAILURE;
+    }
+
+    auto output = openOutputFile(outputFilename, &errorMessage);
+    if (!output) {
+        llvm::errs() << errorMessage << "\n";
+        return EXIT_FAILURE;
+    }
+
+    OwningModuleRef module = processCrabBuffer(output->os(), std::move(file), registry);
+    assert(module);
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This update simply adds a function that returns an `OwningModuleRef` of the parsed mlir file