### PR TITLE
Btor Constraint Op

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 run-script.sh
 include/Target/Btor/btor2parser
 clang-debug
+.vscode

--- a/include/Dialect/Btor/IR/BtorOps.td
+++ b/include/Dialect/Btor/IR/BtorOps.td
@@ -842,8 +842,8 @@ def ConstantOp : Btor_Op<"constant", [ConstantLike, NoSideEffect,
   let hasVerifier = 1;
 }
 
-def AssumeOp : Btor_Op<"assume"> {
-    let summary = "btor assumption";
+def ConstraintOp : Btor_Op<"constraint"> {
+    let summary = "btor constraint";
     let description = [{
         This operation takes one boolean argument and assumes 
         it holds for the program.
@@ -852,14 +852,14 @@ def AssumeOp : Btor_Op<"assume"> {
         
         ```mlir
         %0 = constant 1 : i1
-        // Apply the assume operation to %0
-        btor.assume ( %0 )
+        // Apply the constraint operation to %0
+        btor.constraint ( %0 )
         ```
     }];
 
-    let arguments = (ins I1:$arg);
+    let arguments = (ins I1:$constraint);
 
-    let assemblyFormat = "`(` $arg `)` attr-dict";
+    let assemblyFormat = "`(` $constraint `)` attr-dict";
 }
 
 def UndefOp : Btor_Op<"undef"> {

--- a/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
+++ b/lib/Conversion/BtorToLLVM/BtorToLLVM.cpp
@@ -222,6 +222,13 @@ struct UndefOpLowering : public ConvertOpToLLVMPattern<btor::UndefOp> {
                   ConversionPatternRewriter &rewriter) const override;
 };
 
+struct ConstraintOpLowering : public ConvertOpToLLVMPattern<btor::ConstraintOp> {
+  using ConvertOpToLLVMPattern<btor::ConstraintOp>::ConvertOpToLLVMPattern;
+  LogicalResult
+  matchAndRewrite(btor::ConstraintOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
 } // end anonymous namespace
 
 //===----------------------------------------------------------------------===//
@@ -574,6 +581,16 @@ UndefOpLowering::matchAndRewrite(btor::UndefOp op, OpAdaptor adaptor,
 }
 
 //===----------------------------------------------------------------------===//
+// ConstraintOpLowering
+//===----------------------------------------------------------------------===//
+LogicalResult
+ConstraintOpLowering::matchAndRewrite(btor::ConstraintOp op, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const {
+  rewriter.replaceOpWithNewOp<LLVM::AssumeOp>(op, op.constraint());
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Pass Definition
 //===----------------------------------------------------------------------===//
 
@@ -652,8 +669,8 @@ void mlir::btor::populateBtorToLLVMConversionPatterns(
       IffOpLowering, ImpliesOpLowering, XnorOpLowering, NandOpLowering,
       NorOpLowering, IncOpLowering, DecOpLowering, NegOpLowering,
       RedOrOpLowering, RedAndOpLowering, RedXorOpLowering, UExtOpLowering,
-      SExtOpLowering, SliceOpLowering, ConcatOpLowering, UndefOpLowering>(
-      converter);
+      SExtOpLowering, SliceOpLowering, ConcatOpLowering, UndefOpLowering,
+      ConstraintOpLowering>(converter);
 }
 
 /// Create a pass for lowering operations the remaining `Btor` operations

--- a/lib/Target/Btor/BtorToBtorIRTranslation.cpp
+++ b/lib/Target/Btor/BtorToBtorIRTranslation.cpp
@@ -272,7 +272,7 @@ Operation * Deserialize::createMLIR(const Btor2Line *line,
     res = buildInputOp(line->sort.bitvec.width);
     break;
   case BTOR2_TAG_constraint:
-    res = buildUnaryOp<btor::AssumeOp>(kids[0]);
+    res = buildUnaryOp<btor::ConstraintOp>(kids[0]);
     break;
 
 

--- a/test/Btor/btor-opt.mlir
+++ b/test/Btor/btor-opt.mlir
@@ -4,7 +4,7 @@ module {
     func.func @next( %arg0: i3, %arg1: i3 ) -> (i3, i3) {
         // create assumption
         %cmp_ne = btor.cmp "ne", %arg0, %arg1 : i3
-        btor.assume ( %cmp_ne )
+        btor.constraint ( %cmp_ne )
         // apply transition relation
         %c_0 = btor.constant 1 : i3
         %add_1 = btor.add %arg0, %c_0 : i3


### PR DESCRIPTION
PR to stay true to the `btor.constraint` operation; lowers to the assume operation in llvm 

Taking the file below as input:
```
module {
  func.func @next(%arg0: i3, %arg1: i3) -> (i3, i3) {
    %0 = btor.cmp ne, %arg0, %arg1 : i3
    btor.constraint(%0)
    %1 = btor.constant 1 : i3
    %2 = btor.add %arg0, %1 : i3
    %3 = btor.sub %arg1, %1 : i3
    %4 = btor.cmp ne, %2, %3 : i3
    %5 = btor.redand %4 : i1
    btor.assert_not(%4)
    return %2, %3 : i3, i3
  }
}
```
we get the following mlir in the llvm dialect

```
module attributes {llvm.data_layout = ""} {
  llvm.func @verifier.error()
  llvm.func @next(%arg0: i3, %arg1: i3) -> !llvm.struct<(i3, i3)> {
    %0 = llvm.icmp "ne" %arg0, %arg1 : i3
    "llvm.intr.assume"(%0) : (i1) -> ()
    %1 = llvm.mlir.constant(1 : i3) : i3
    %2 = llvm.add %arg0, %1  : i3
    %3 = llvm.sub %arg1, %1  : i3
    %4 = llvm.icmp "ne" %2, %3 : i3
    %5 = llvm.bitcast %4 : i1 to vector<1xi1>
    %6 = "llvm.intr.vector.reduce.and"(%5) : (vector<1xi1>) -> i1
    %7 = llvm.mlir.constant(true) : i1
    %8 = llvm.xor %4, %7  : i1
    llvm.cond_br %8, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    %9 = llvm.mlir.undef : !llvm.struct<(i3, i3)>
    %10 = llvm.insertvalue %2, %9[0] : !llvm.struct<(i3, i3)>
    %11 = llvm.insertvalue %3, %10[1] : !llvm.struct<(i3, i3)>
    llvm.return %11 : !llvm.struct<(i3, i3)>
  ^bb2:  // pred: ^bb0
    llvm.call @verifier.error() : () -> ()
    llvm.unreachable
  }
}
```